### PR TITLE
Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ julia> Pkg.add("Dierckx")
 ```
 
 The Fortran library source code is distributed with the package, so
-you need a Fortran compiler. On Ubuntu, `sudo apt-get install gfortran`
-will do it.
+you need a Fortran compiler on OSX or Linux. On Ubuntu,
+`sudo apt-get install gfortran` will do it.
 
-Windows is not yet supported.
+On Windows, a compiled dll will be downloaded.
 
 Example Usage
 -------------

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,17 @@
-cd(joinpath(dirname(@__FILE__), "src", "ddierckx"))
+@unix_only begin
+    cd(joinpath(dirname(@__FILE__), "src", "ddierckx"))
 
-suffix = @linux? "so" : @osx? "dylib" : error("only linux and osx supported")
-run(`make FC=gfortran SUFFIX=$suffix`) 
+    suffix = @osx? "dylib" : "so"
+    run(`make FC=gfortran SUFFIX=$suffix`)
+end
+
+@windows_only begin
+    # these binaries were cross-compiled from Cygwin via the following steps:
+    # mkdir -p bin32 && mkdir -p bin64
+    # i686-w64-mingw32-gfortran -o bin32/libddierckx.dll -O3 -shared \
+    #   -static-libgfortran -static-libgcc src/ddierckx/*.f
+    # x86_64-w64-mingw32-gfortran -o bin64/libddierckx.dll -O3 -shared \
+    #   -static-libgfortran -static-libgcc src/ddierckx/*.f
+    run(`curl -LO http://sourceforge.net/projects/juliadeps-win/files/ddierckx.7z`)
+    run(`7z x -y ddierckx.7z`)
+end

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -9,7 +9,7 @@ export Spline1D,
        get_residual
 
 const ddierckx = joinpath(dirname(@__FILE__),
-                          "../deps/src/ddierckx/libddierckx")
+    @unix? "../deps/src/ddierckx/libddierckx" : "../deps/bin$WORD_SIZE/libddierckx")
 
 # Ensure library is available.
 if (dlopen_e(ddierckx) == C_NULL)


### PR DESCRIPTION
You can host the binaries elsewhere if you'd prefer. You don't have access to a 32-bit Linux machine by any chance, do you? It looks like there are some precision issues in the tests for win32:

```
julia> Pkg.test("Dierckx")
INFO: Testing Dierckx
ERROR: assertion failed: |get_residual(spl) - 0.0| <= 1.7105694144590052e-45
  get_residual(spl) = 1.3349971792853637e-33
  0.0 = 0.0
  difference = 1.3349971792853637e-33 > 1.7105694144590052e-45
while loading C:\Users\Tony\.julia\Dierckx\test\runtests.jl, in expression starting on line 20
```

I found the `@unix?` macro in `src/Dierckx.jl` was really picky about being on a single line, so keep an eye out for that.
