### PR TITLE
Fix deprecation warnings and a precompilation error

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3-
-Compat
+Compat 0.3.6

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -17,9 +17,11 @@ unixpath = "../deps/src/ddierckx/libddierckx"
 winpath = "../deps/bin$WORD_SIZE/libddierckx"
 const ddierckx = joinpath(dirname(@__FILE__), @unix? unixpath : winpath)
 
-# Ensure library is available.
-if (dlopen_e(ddierckx) == C_NULL)
-    error("Dierckx not properly installed. Run Pkg.build(\"Dierckx\")")
+function __init__()
+    # Ensure library is available.
+    if (Libdl.dlopen_e(ddierckx) == C_NULL)
+        error("Dierckx not properly installed. Run Pkg.build(\"Dierckx\")")
+    end
 end
 
 # ----------------------------------------------------------------------------

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -138,7 +138,7 @@ function Spline1D(x::Vector{Float64}, y::Vector{Float64};
            Ptr{Float64}, Ptr{Float64}, Ptr{Float64},  # t, c, fp
            Ptr{Float64}, Ptr{Int32}, Ptr{Int32},  # wrk, lwrk, iwrk
            Ptr{Int32}),  # ier
-          &0, &m, x, y, w, &x[1], &x[end], &k, &Float64(s), &nest,
+          &0, &m, x, y, w, &x[1], &x[end], &k, &@compat(Float64(s)), &nest,
           n, t, c, fp, wrk, &lwrk, iwrk, ier)
 
     ier[1] <= 0 || error(_fit1d_messages[ier[1]])
@@ -422,7 +422,7 @@ function Spline2D(x::Vector{Float64}, y::Vector{Float64}, z::Vector{Float64};
            Ptr{Float64}, Ptr{Int32},  # wrk1, lwrk1
            Ptr{Float64}, Ptr{Int32},  # wrk2, lwrk2
            Ptr{Int32}, Ptr{Int32}, Ptr{Int32}),   # iwrk, kwrk, ier
-          &0, &m, y, x, z, w, &yb, &ye, &xb, &xe, &ky, &kx, &Float64(s),
+          &0, &m, y, x, z, w, &yb, &ye, &xb, &xe, &ky, &kx, &@compat(Float64(s)),
           &nyest, &nxest, &nmax, &eps, ny, ty, nx, tx, c, fp,
           wrk1, &lwrk1, wrk2, &lwrk2, iwrk, &kwrk, ier)
 
@@ -531,7 +531,7 @@ function Spline2D(x::Vector{Float64}, y::Vector{Float64}, z::Array{Float64,2};
            Ptr{Float64}, Ptr{Int32},  # wrk, lwrk
            Ptr{Int32}, Ptr{Int32},  # iwrk, lwrk
            Ptr{Int32}),  # ier
-          &0f0, &my, y, &mx, x, z, &yb, &ye, &xb, &xe, &ky, &kx, &Float64(s),
+          &0f0, &my, y, &mx, x, z, &yb, &ye, &xb, &xe, &ky, &kx, &@compat(Float64(s)),
           &nyest, &nxest, ny, ty, nx, tx, c, fp,
           wrk, &lwrk, iwrk, &kwrk, ier)
     

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -138,7 +138,7 @@ function Spline1D(x::Vector{Float64}, y::Vector{Float64};
            Ptr{Float64}, Ptr{Float64}, Ptr{Float64},  # t, c, fp
            Ptr{Float64}, Ptr{Int32}, Ptr{Int32},  # wrk, lwrk, iwrk
            Ptr{Int32}),  # ier
-          &0, &m, x, y, w, &x[1], &x[end], &k, &float64(s), &nest,
+          &0, &m, x, y, w, &x[1], &x[end], &k, &Float64(s), &nest,
           n, t, c, fp, wrk, &lwrk, iwrk, ier)
 
     ier[1] <= 0 || error(_fit1d_messages[ier[1]])
@@ -377,8 +377,8 @@ function Spline2D(x::Vector{Float64}, y::Vector{Float64}, z::Vector{Float64};
     (length(y) == length(z) == m) || error("lengths of x, y, z must match") 
     (length(w) == m) || error("length of w must match other inputs")
 
-    nxest = max(kx+1+iceil(sqrt(m/2)), 2*(kx+1))
-    nyest = max(ky+1+iceil(sqrt(m/2)), 2*(ky+1))
+    nxest = max(kx+1+ceil(Int,sqrt(m/2)), 2*(kx+1))
+    nyest = max(ky+1+ceil(Int,sqrt(m/2)), 2*(ky+1))
     nmax = max(nxest, nyest)
 
     eps = 1.0e-16
@@ -422,7 +422,7 @@ function Spline2D(x::Vector{Float64}, y::Vector{Float64}, z::Vector{Float64};
            Ptr{Float64}, Ptr{Int32},  # wrk1, lwrk1
            Ptr{Float64}, Ptr{Int32},  # wrk2, lwrk2
            Ptr{Int32}, Ptr{Int32}, Ptr{Int32}),   # iwrk, kwrk, ier
-          &0, &m, y, x, z, w, &yb, &ye, &xb, &xe, &ky, &kx, &float64(s),
+          &0, &m, y, x, z, w, &yb, &ye, &xb, &xe, &ky, &kx, &Float64(s),
           &nyest, &nxest, &nmax, &eps, ny, ty, nx, tx, c, fp,
           wrk1, &lwrk1, wrk2, &lwrk2, iwrk, &kwrk, ier)
 
@@ -531,7 +531,7 @@ function Spline2D(x::Vector{Float64}, y::Vector{Float64}, z::Array{Float64,2};
            Ptr{Float64}, Ptr{Int32},  # wrk, lwrk
            Ptr{Int32}, Ptr{Int32},  # iwrk, lwrk
            Ptr{Int32}),  # ier
-          &0f0, &my, y, &mx, x, z, &yb, &ye, &xb, &xe, &ky, &kx, &float64(s),
+          &0f0, &my, y, &mx, x, z, &yb, &ye, &xb, &xe, &ky, &kx, &Float64(s),
           &nyest, &nxest, ny, ty, nx, tx, c, fp,
           wrk, &lwrk, iwrk, &kwrk, ier)
     


### PR DESCRIPTION
I like to add a bunch of packages to `userimg.jl` to help alleviate the slow loading times when I deploy code for my group. Dierckx fails to precompile without moving the `dlopen` check to the `__init__` method.

I've also fixed an assortment of deprecations warnings. I still get two, but they don't seem to be coming from Dierckx:

```
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-dev+3951 (2015-03-20 22:53 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit e13c9be (2 days old master)
|__/                   |  x86_64-unknown-linux-gnu

julia> Pkg.test("Dierckx")
INFO: Testing Dierckx
WARNING: float64(x) is deprecated, use Float64(x) instead.
 in depwarn at ./deprecated.jl:40
 in float64 at deprecated.jl:29
 in include at ./boot.jl:250
 in include_from_node1 at loading.jl:129
 in process_options at ./client.jl:318
 in _start at ./client.jl:402
WARNING: [a] concatenation is deprecated; use [a;] instead
 in depwarn at ./deprecated.jl:40
 in oldstyle_vcat_warning at ./abstractarray.jl:26
 in vect at abstractarray.jl:29
 in include at ./boot.jl:250
 in include_from_node1 at loading.jl:129
 in process_options at ./client.jl:318
 in _start at ./client.jl:402
All tests passed.
INFO: Dierckx tests passed
INFO: No packages to install, update or remove
```