### PR TITLE
Fixes Type Instability in _evaluate and _derivative

### DIFF
--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -257,8 +257,12 @@ function Spline1D(x::AbstractVector, y::AbstractVector,
     return Spline1D(t, c, k, _translate_bc(bc), fp[])
 end
 
-function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                   x::Vector{Float64}; bc::Int=0)
+# TODO: deprecate this
+_evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int, x; bc::Int=0) =
+    __evaluate(t, c, k, x, bc)
+
+function __evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
+                   x::Vector{Float64}, bc::Int=0)
     bc in (0, 1, 2, 3) || error("bc = $bc not in (0, 1, 2, 3)")
     m = length(x)
     xin = convert(Vector{Float64}, x)
@@ -275,8 +279,8 @@ function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
     return y
 end
 
-function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                   x::Real; bc::Int=0)
+function __evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
+                   x::Real, bc::Int=0)
     bc in (0, 1, 2, 3) || error("bc = $bc not in (0, 1, 2, 3)")
     y = Ref{Float64}(0)
     ier = Ref{Int32}(0)
@@ -293,11 +297,12 @@ end
 
 function evaluate(spline::Spline1D, x::AbstractVector)
     xin = convert(Vector{Float64}, x)
-    _evaluate(spline.t, spline.c, spline.k, xin, bc=spline.bc)
+    __evaluate(spline.t, spline.c, spline.k, xin, spline.bc)
 end
 
 evaluate(spline::Spline1D, x::Real) =
-    _evaluate(spline.t, spline.c, spline.k, x, bc=spline.bc)
+    __evaluate(spline.t, spline.c, spline.k, x, spline.bc)
+
 
 function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
                      x::Vector{Float64}; nu::Int=1, bc::Int=0)

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -257,7 +257,7 @@ function Spline1D(x::AbstractVector, y::AbstractVector,
     return Spline1D(t, c, k, _translate_bc(bc), fp[])
 end
 
-# TODO: deprecate this
+# TODO: deprecate this?
 _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int, x; bc::Int=0) =
     __evaluate(t, c, k, x, bc)
 
@@ -304,8 +304,14 @@ evaluate(spline::Spline1D, x::Real) =
     __evaluate(spline.t, spline.c, spline.k, x, spline.bc)
 
 
-function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                     x::Vector{Float64}; nu::Int=1, bc::Int=0)
+# TODO: deprecate this?
+_derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int, x;
+            nu::Int=1, bc::Int=0) =
+    __derivative(t, c, k, x, nu, bc)
+
+
+function __derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
+                     x::Vector{Float64}, nu::Int=1, bc::Int=0)
     (1 <= nu <= k) || error("order of derivative must be positive and less than or equal to spline order")
     m = length(x)
     n = length(t)
@@ -323,8 +329,8 @@ function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
     return y
 end
 
-function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                     x::Real; nu::Int=1, bc::Int=0)
+function __derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
+                     x::Real, nu::Int=1, bc::Int=0)
     (1 <= nu <= k) || error("order of derivative must be positive and less than or equal to spline order")
     n = length(t)
     wrk = Vector{Float64}(n)
@@ -345,13 +351,18 @@ end
 #       or should it be integrated with evaluate, above?
 #       (problem with that: derivative doesn't accept bc="nearest")
 # TODO: should `nu` be `d`?
-function derivative(spline::Spline1D, x::AbstractVector; nu::Int=1)
+function derivative(spline::Spline1D, x::AbstractVector, nu::Int=1)
     xin = convert(Vector{Float64}, x)
-    _derivative(spline.t, spline.c, spline.k, xin; nu=nu, bc=spline.bc)
+    __derivative(spline.t, spline.c, spline.k, xin, nu, spline.bc)
 end
 
-derivative(spline::Spline1D, x::Real; nu::Int=1) =
-    _derivative(spline.t, spline.c, spline.k, x; nu=nu, bc=spline.bc)
+derivative(spline::Spline1D, x::Real, nu::Int=1) =
+    __derivative(spline.t, spline.c, spline.k, x, nu, spline.bc)
+
+
+# TODO: deprecate this?
+derivative(spline::Spline1D, x; nu::Int=1) = derivative(spline, x, nu)
+
 
 function _integrate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
                     a::Real, b::Real)


### PR DESCRIPTION
This mini-PR fixes a type instability in `_evaluate`, `_derivative` and `derivative` caused by using kwargs. This can be seen if one makes many calls with just a scalar argument:

```
# OLD TIMINGS 
# evaluate 
#   0.018588 seconds (500.00 k allocations: 15.259 MB, 11.57% gc time)
#   0.017436 seconds (500.00 k allocations: 15.259 MB, 7.48% gc time)
# first derivative
#   0.020274 seconds (600.00 k allocations: 33.569 MB, 6.01% gc time)
#   0.020318 seconds (600.00 k allocations: 33.569 MB, 11.01% gc time)
# second derivative
#   0.027993 seconds (700.00 k allocations: 42.725 MB, 11.26% gc time)
#   0.026323 seconds (700.00 k allocations: 42.725 MB, 10.23% gc time)

# NEW TIMINGS 
# evaluate 
#   0.009857 seconds (200.00 k allocations: 3.052 MB)
#   0.009378 seconds (200.00 k allocations: 3.052 MB)
# first derivative
#   0.012261 seconds (300.00 k allocations: 19.837 MB, 8.79% gc time)
#   0.012860 seconds (300.00 k allocations: 19.837 MB, 6.69% gc time)
# second derivative
#   0.019107 seconds (400.00 k allocations: 28.992 MB, 11.40% gc time)
#   0.018948 seconds (400.00 k allocations: 28.992 MB, 11.45% gc time)
```