### PR TITLE
allow wrk array to be passed by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ z = [1. 2. 1. 2.;  # size is (length(x), length(y))
 spline = Spline2D(x, y, z)
 ```
 
+*Note that if you consider `z` as a matrix, `x` refers to row
+ coordinates and `y` refers to column coordinates.*
+
 Evaluate at element-wise points:
 
 ```julia
@@ -191,8 +194,10 @@ Spline2D(x, y, z; kx=3, ky=3, s=0.0)
   `(x[i], y[i])`. In this case, the lengths of all inputs must match.
 
   If `z` is a 2-d array, the data are assumed to be gridded: `z[i, j]`
-  is the function value at `(x[i], y[j])`. In this case, it is required
-  that `size(z) == (length(x), length(y))`.
+  is the function value at `(x[i], y[j])`. In this case, it is
+  required that `size(z) == (length(x), length(y))`. (Note that when
+  interpreting `z` as a matrix, `x` gives the row coordinates and `y`
+  gives the column coordinates.)
 
 ```julia
 evaluate(spl, x, y)
@@ -207,8 +212,12 @@ evalgrid(spl, x, y)
 ```
 
 - Evaluate the 2-d spline `spl` at the grid points spanned by the
-  coordinate arrays `x` and `y`. The input arrays must be monotonically
-  increasing.
+  coordinate arrays `x` and `y`. The input arrays must be
+  monotonically increasing. The output is a 2-d array with size
+  `(length(x), length(y))`: `output[i, j]` is the function value at
+  `(x[i], y[j])`. In other words, when interpreting the result as a
+  matrix, `x` gives the row coordinates and `y` gives the column
+  coordinates.
 
 - integral of a 2-d spline over the domain `[x0, x1]*[y0, y1]`
 

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -412,7 +412,11 @@ type ParametricSpline
     k::Int
     bc::Int
     fp::Float64
+    wrk::Vector{Float64}
 end
+
+ParametricSpline(t, c, k, bc, fp) =
+    ParametricSpline(t, c, k, bc, fp, Vector{Float64}(length(t)))
 
 get_knots(spl::ParametricSpline) = spl.t[spl.k+1:end-spl.k]
 get_coeffs(spl::ParametricSpline) = spl.c[:, 1:end-spl.k+1]
@@ -852,26 +856,29 @@ evaluate(spline::ParametricSpline, x::Real) =
     _evaluate(spline.t, spline.c, spline.k, x, spline.bc)
 
 _derivative(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-            x::Vector{Float64}, nu::Int, bc::Int) =
-    mapslices(v -> _derivative(t, v, k, x, nu, bc), c, [2])
+            x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64}) =
+    mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, [2])
 
 _derivative(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-            x::Real, nu::Int, bc::Int) =
-    vec(mapslices(v -> _derivative(t, v, k, x, nu, bc), c, [2]))
+            x::Real, nu::Int, bc::Int, wrk::Vector{Float64}) =
+    vec(mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, [2]))
 
-derivative(spline::ParametricSpline, x::AbstractVector; nu::Int=1) =
+derivative(spline::ParametricSpline, x::AbstractVector, nu::Int=1) =
     _derivative(spline.t, spline.c, spline.k,
-                convert(Vector{Float64}, x), nu, spline.bc)
+                convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
 
-derivative(spline::ParametricSpline, x::Real; nu::Int=1) =
-    _derivative(spline.t, spline.c, spline.k, x, nu, spline.bc)
+# TODO: deprecate this
+derivative(spline::ParametricSpline, x; nu::Int=1) = derivative(spline, x, nu)
+
+derivative(spline::ParametricSpline, x::Real, nu::Int=1) =
+    _derivative(spline.t, spline.c, spline.k, x, nu, spline.bc, spline.wrk)
 
 _integrate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-           a::Real, b::Real) =
-    vec(mapslices(v -> _integrate(t, v, k, a, b), c, [2]))
+           a::Real, b::Real, wrk::Vector{Float64}) =
+    vec(mapslices(v -> _integrate(t, v, k, a, b, wrk), c, [2]))
 
 integrate(spline::ParametricSpline, a::Real, b::Real) =
-    _integrate(spline.t, spline.c, spline.k, a, b)
+    _integrate(spline.t, spline.c, spline.k, a, b, spline.wrk)
 
 # ----------------------------------------------------------------------------
 # 2-d splines


### PR DESCRIPTION
This is another small performance improvement. (I didn't spot this until after I had submitted the previous pull request - my apologies.) 

This does not change default behaviour, but it gives the user the opportunity to pass a `wrk` array into `derivative` so that it doesn't have to be allocated every time. This gives again an advantage when one does many evaluations with scalar arguments. Here are the timings:

```
# OLD TIMINGS 
# evaluate 
#   0.018588 seconds (500.00 k allocations: 15.259 MB, 11.57% gc time)
#   0.017436 seconds (500.00 k allocations: 15.259 MB, 7.48% gc time)
# first derivative
#   0.020274 seconds (600.00 k allocations: 33.569 MB, 6.01% gc time)
#   0.020318 seconds (600.00 k allocations: 33.569 MB, 11.01% gc time)
# second derivative
#   0.027993 seconds (700.00 k allocations: 42.725 MB, 11.26% gc time)
#   0.026323 seconds (700.00 k allocations: 42.725 MB, 10.23% gc time)

# NEW TIMINGS: REMOVE TYPE INSTABILITY
# evaluate 
#   0.009857 seconds (200.00 k allocations: 3.052 MB)
#   0.009378 seconds (200.00 k allocations: 3.052 MB)
# first derivative
#   0.012261 seconds (300.00 k allocations: 19.837 MB, 8.79% gc time)
#   0.012860 seconds (300.00 k allocations: 19.837 MB, 6.69% gc time)
# second derivative
#   0.019107 seconds (400.00 k allocations: 28.992 MB, 11.40% gc time)
#   0.018948 seconds (400.00 k allocations: 28.992 MB, 11.45% gc time)

# NEW TIMINGS: WORK ARRAY PASSED AS AN ARGUMENT 
# evaluate 
#   0.010958 seconds (200.00 k allocations: 3.052 MB)
#   0.009265 seconds (200.00 k allocations: 3.052 MB)
# first derivative
#   0.008837 seconds (200.00 k allocations: 3.052 MB)
#   0.009624 seconds (200.00 k allocations: 3.052 MB)
# second derivative
#   0.009792 seconds (200.00 k allocations: 3.052 MB)
#   0.009251 seconds (200.00 k allocations: 3.052 MB)
```