### PR TITLE
Fixed warn deprecation + tests raising warnings

### DIFF
--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -385,7 +385,7 @@ function roots(spline::Spline1D; maxn::Integer=8)
     if ier[1] == 0
         return zeros[1:m[1]]
     elseif ier[1] == 1
-        warn("number of zeros exceeded maxn; only first maxn zeros returned")
+        @warn("number of zeros exceeded maxn; only first maxn zeros returned")
         return zeros
     elseif ier[1] == 10
         error("Invalid input data.")
@@ -825,7 +825,7 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
     if (ier[] == 0 || ier[] == -1 || ier[] == -2)
         # good values, pass.
     elseif ier[] < -2
-        warn("""
+        @warn("""
         The coefficients of the spline returned have been
         computed as the minimal norm least-squares solution of a
         (numerically) rank deficient system. The rank is $(-ier[]).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,10 +326,4 @@ sp5 = Spline2D(x, y, z.+1)
 @test sp1 == sp2
 @test allunique([sp1, sp3, sp4, sp5])
 
-# test bad least squares / rank deficient warning
-x = 1.0 .+ (0:100)*2e-16
-y = 1.0 .+ (100:-1:0)*2e-16;
-z = (-1).^(0:100) 
-@test_logs (:warn,Regex("rank deficient")) Spline2D(x,y,z,s=85)
-
 println("All tests passed.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,11 @@ sp4 = ParametricSpline(x, y.+1)
 @test sp1 == sp2
 @test allunique([sp1,sp3,sp4])
 
+# test too many roots warning
+x = (0:100)
+y = (-1).^(0:100)
+sp = Spline1D(x,y)
+@test_logs (:warn,Regex("number of zeros exceeded")) roots(sp)
 
 
 # -----------------------------------------------------------------------------
@@ -321,5 +326,10 @@ sp5 = Spline2D(x, y, z.+1)
 @test sp1 == sp2
 @test allunique([sp1, sp3, sp4, sp5])
 
+# test bad least squares / rank deficient warning
+x = 1.0 .+ (0:100)*2e-16
+y = 1.0 .+ (100:-1:0)*2e-16;
+z = (-1).^(0:100) 
+@test_logs (:warn,Regex("rank deficient")) Spline2D(x,y,z,s=85)
 
 println("All tests passed.")


### PR DESCRIPTION
It seems `warn` has been deprecated since Julia v0.7 and we should be using the `@warn` macro instead. `warn` is used in two locations:`roots` and `Splined2D`. This PR also adds tests for warnings being issued in the following.
1.  in `roots` when there are more roots than the maximum number of roots
2.  in `Spline2D` when some internal least squares problem that is solved by the Fortran code is rank deficient. This example was harder to come by and required adjusting `s` carefully. Since rank-deficiency could be compiler/processor/platform dependent, it may be better to remove this test (but still keeping the changes in `src/Dierckx.jl`)