### PR TITLE
Allow `Dierckx_jll` v0.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "Dierckx"
 uuid = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 repo = "https://github.com/kbarbary/Dierckx.jl.git"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Dierckx_jll = "cd4c43a9-7502-52ba-aa6d-59fb2a88580b"
 
 [compat]
-Dierckx_jll = "0.0.1"
+Dierckx_jll = "0.0.1, 0.1"
 julia = "1.3"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -35,18 +35,7 @@ Install (Julia 1.3 and later)
 (v1.3) pkg> add Dierckx
 ```
 
-(Type `]` to enter package mode.) No Fortran compiler is required on
-any platform.
-
-
-The Fortran library source code is distributed with the package, so
-you need a Fortran compiler on OSX or Linux. On Ubuntu,
-`sudo apt-get install gfortran` will do it.
-
-On Darwin, `gfortran` comes bundled with `gcc`, so after installing Homebrew,
-`brew install gcc` should install `gfortran`.
-
-On Windows, a compiled dll will be downloaded.
+(Type `]` to enter package mode.)
 
 Example Usage
 -------------


### PR DESCRIPTION
Could you please tag a new version after this is merged?  Thanks!

Fixes #85 