### PR TITLE
Partial derivatives for 2D splines

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use case not covered here.
 
 All new development on `Dierckx.jl` will be for Julia v1.3 and above.
 The `master` branch is therefore incompatible with earlier versions
-of Julia. 
+of Julia.
 
 ### Features
 
@@ -244,6 +244,16 @@ evalgrid(spl, x, y)
   `(x[i], y[j])`. In other words, when interpreting the result as a
   matrix, `x` gives the row coordinates and `y` gives the column
   coordinates.
+
+```julia
+derivative(spl, x, y; nux = 1, nuy = 1)
+```
+
+- Evaluate the partial derivative of the 2-d spline `spl` at the
+  grid points spanned by the coordinate arrays `x` and `y`.
+  Note that `x` refers to the row coordinates, and `y` to the column
+  ones. The order of the derivatives may be between `0` and `kx-1` for `x`
+  and `0` and `ky-1` for `y`.
 
 - integral of a 2-d spline over the domain `[x0, x1]*[y0, y1]`
 

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -3,16 +3,16 @@ module Dierckx
 using Dierckx_jll
 
 export Spline1D,
-    Spline2D,
-    ParametricSpline,
-    evaluate,
-    derivative,
-    integrate,
-    roots,
-    evalgrid,
-    get_knots,
-    get_coeffs,
-    get_residual
+       Spline2D,
+       ParametricSpline,
+       evaluate,
+       derivative,
+       integrate,
+       roots,
+       evalgrid,
+       get_knots,
+       get_coeffs,
+       get_residual
 
 import Base: show, ==
 
@@ -20,39 +20,44 @@ import Base: show, ==
 # 1-d splines
 
 const _fit1d_messages = Dict(
-    2 => """A theoretically impossible result was found during the iteration
-         process for finding a smoothing spline with fp = s: s too small.
-         There is an approximation returned but the corresponding weighted sum
-         of squared residuals does not satisfy the condition abs(fp-s)/s <
-         tol.""",
-    3 => """The maximal number of iterations maxit (set to 20 by the program)
-         allowed for finding a smoothing spline with fp=s has been reached: s
-         too small. There is an approximation returned but the corresponding
-         weighted sum of squared residuals does not satisfy the condition
-         abs(fp-s)/s < tol.""",
-    10 => """Error on entry, no approximation returned. The following conditions
-          must hold:
-          1<=k<=5
-          x[1] < x[2] < ... < x[end]
-          w[i] > 0.0 for all i
+2=>
+"""A theoretically impossible result was found during the iteration
+process for finding a smoothing spline with fp = s: s too small.
+There is an approximation returned but the corresponding weighted sum
+of squared residuals does not satisfy the condition abs(fp-s)/s <
+tol.""",
+3=>
+"""The maximal number of iterations maxit (set to 20 by the program)
+allowed for finding a smoothing spline with fp=s has been reached: s
+too small. There is an approximation returned but the corresponding
+weighted sum of squared residuals does not satisfy the condition
+abs(fp-s)/s < tol.""",
+10=>
+"""Error on entry, no approximation returned. The following conditions
+must hold:
+1<=k<=5
+x[1] < x[2] < ... < x[end]
+w[i] > 0.0 for all i
 
-          Additionally, if spline knots are given:
-          length(xknots) <= length(x) + k + 1
-          x[1] < xknots[1] < xknots[k+2] < ... < xknots[end] < x[end]
-          The schoenberg-whitney conditions: there must be a subset of data points
-          xx[j] such that t[j] < xx[j] < t[j+k+1] for j=1,2,...,n-k-1""")
+Additionally, if spline knots are given:
+length(xknots) <= length(x) + k + 1
+x[1] < xknots[1] < xknots[k+2] < ... < xknots[end] < x[end]
+The schoenberg-whitney conditions: there must be a subset of data points
+xx[j] such that t[j] < xx[j] < t[j+k+1] for j=1,2,...,n-k-1""")
 
 
 const _eval1d_messages = Dict(
-    1 => """Input point out of range""",
-    10 => """Invalid input data. The following conditions must hold:
-          length(x) != 0 and xb <= x[1] <= x[2] <= ... x[end] <= xe""")
+1=>
+"""Input point out of range""",
+10=>
+"""Invalid input data. The following conditions must hold:
+length(x) != 0 and xb <= x[1] <= x[2] <= ... x[end] <= xe""")
 
 _translate_bc(bc::AbstractString) = (bc == "extrapolate" ? 0 :
-                                     bc == "zero" ? 1 :
-                                     bc == "error" ? 2 :
-                                     bc == "nearest" ? 3 :
-                                     error("unknown boundary condition: \"$bc\""))
+                             bc == "zero" ? 1 :
+                             bc == "error" ? 2 :
+                             bc == "nearest" ? 3 :
+                             error("unknown boundary condition: \"$bc\""))
 _translate_bc(bc::Int) = (bc == 0 ? "extrapolate" :
                           bc == 1 ? "zero" :
                           bc == 2 ? "error" :
@@ -104,9 +109,9 @@ function show(io::IO, spl::Spline1D)
 end
 
 function Spline1D(x::AbstractVector, y::AbstractVector;
-    w::AbstractVector = ones(length(x)),
-    k::Int = 3, s::Real = 0.0, bc::AbstractString = "nearest",
-    periodic::Bool = false)
+                  w::AbstractVector=ones(length(x)),
+                  k::Int=3, s::Real=0.0, bc::AbstractString="nearest",
+                  periodic::Bool=false)
     m = length(x)
     length(y) == m || error("length of x and y must match")
     length(w) == m || error("length of x and w must match")
@@ -135,9 +140,9 @@ function Spline1D(x::AbstractVector, y::AbstractVector;
     # workspace
     lwrk = 0
     if periodic
-        lwrk = m * (k + 1) + nest * (8 + 5k)
+        lwrk = m * (k + 1) + nest*(8 + 5k)
     else
-        lwrk = m * (k + 1) + nest * (7 + 3k)
+        lwrk = m * (k + 1) + nest*(7 + 3k)
     end
     wrk = Vector{Float64}(undef, lwrk)
     iwrk = Vector{Int32}(undef, nest)
@@ -145,24 +150,24 @@ function Spline1D(x::AbstractVector, y::AbstractVector;
     if !periodic
         ccall((:curfit_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32},  # iopt, m
-                Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
-                Ref{Float64}, Ref{Float64},  # xb, xe
-                Ref{Int32}, Ref{Float64},  # k, s
-                Ref{Int32}, Ref{Int32}, # nest, n
-                Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
-                Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
-                Ref{Int32}),  # ier
+             Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
+             Ref{Float64}, Ref{Float64},  # xb, xe
+             Ref{Int32}, Ref{Float64},  # k, s
+             Ref{Int32}, Ref{Int32}, # nest, n
+             Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
+             Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
+             Ref{Int32}),  # ier
             0, m, xin, yin, win, xin[1], xin[end], k, Float64(s),
             nest, n, t, c, fp, wrk, lwrk, iwrk, ier)
     else
         ccall((:percur_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32}, # iopt, m
-                Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
-                Ref{Int32}, Ref{Float64}, # k, s
-                Ref{Int32}, Ref{Int32}, # nest, n
-                Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
-                Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
-                Ref{Int32}), # ier
+             Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
+             Ref{Int32}, Ref{Float64}, # k, s
+             Ref{Int32}, Ref{Int32}, # nest, n
+             Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
+             Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
+             Ref{Int32}), # ier
             0, m, xin, yin, win, k, Float64(s), nest, n, t, c,
             fp, wrk, lwrk, iwrk, ier)
     end
@@ -178,10 +183,10 @@ end
 
 # version with user-supplied knots
 function Spline1D(x::AbstractVector, y::AbstractVector,
-    knots::AbstractVector;
-    w::AbstractVector = ones(length(x)),
-    k::Int = 3, bc::AbstractString = "nearest",
-    periodic::Bool = false)
+                  knots::AbstractVector;
+                  w::AbstractVector=ones(length(x)),
+                  k::Int=3, bc::AbstractString="nearest",
+                  periodic::Bool=false)
     m = length(x)
     length(y) == m || error("length of x and y must match")
     length(w) == m || error("length of x and w must match")
@@ -209,9 +214,9 @@ function Spline1D(x::AbstractVector, y::AbstractVector,
     # workspace
     lwrk = 0
     if periodic
-        lwrk = m * (k + 1) + n * (8 + 5k)
+        lwrk = m * (k + 1) + n*(8 + 5k)
     else
-        lwrk = m * (k + 1) + n * (7 + 3k)
+        lwrk = m * (k + 1) + n*(7 + 3k)
     end
     wrk = Vector{Float64}(undef, lwrk)
     iwrk = Vector{Int32}(undef, n)
@@ -219,24 +224,24 @@ function Spline1D(x::AbstractVector, y::AbstractVector,
     if !periodic
         ccall((:curfit_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32},  # iopt, m
-                Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
-                Ref{Float64}, Ref{Float64},  # xb, xe
-                Ref{Int32}, Ref{Float64},  # k, s
-                Ref{Int32}, Ref{Int32}, # nest, n
-                Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
-                Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
-                Ref{Int32}),  # ier
+             Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
+             Ref{Float64}, Ref{Float64},  # xb, xe
+             Ref{Int32}, Ref{Float64},  # k, s
+             Ref{Int32}, Ref{Int32}, # nest, n
+             Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
+             Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
+             Ref{Int32}),  # ier
             -1, m, xin, yin, win, xin[1], xin[end], k, -1.0,
             n, n, t, c, fp, wrk, lwrk, iwrk, ier)
     else
         ccall((:percur_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32}, # iopt, m
-                Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
-                Ref{Int32}, Ref{Float64}, # k, s
-                Ref{Int32}, Ref{Int32}, # nest, n
-                Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
-                Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
-                Ref{Int32}), # ier
+             Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
+             Ref{Int32}, Ref{Float64}, # k, s
+             Ref{Int32}, Ref{Int32}, # nest, n
+             Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
+             Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
+             Ref{Int32}), # ier
             -1, m, xin, yin, win, k, -1.0, n, n, t, c,
             fp, wrk, lwrk, iwrk, ier)
     end
@@ -249,34 +254,34 @@ end
 
 
 function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-    x::Vector{Float64}, bc::Int)
+                   x::Vector{Float64}, bc::Int)
     bc in (0, 1, 2, 3) || error("bc = $bc not in (0, 1, 2, 3)")
     m = length(x)
     xin = convert(Vector{Float64}, x)
     y = Vector{Float64}(undef, m)
     ier = Ref{Int32}(0)
     ccall((:splev_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32},
-            Ref{Float64}, Ref{Int32},
-            Ref{Float64}, Ref{Float64}, Ref{Int32},
-            Ref{Int32}, Ref{Int32}),
-        t, length(t), c, k, xin, y, m, bc, ier)
+         (Ref{Float64}, Ref{Int32},
+          Ref{Float64}, Ref{Int32},
+          Ref{Float64}, Ref{Float64}, Ref{Int32},
+          Ref{Int32}, Ref{Int32}),
+         t, length(t), c, k, xin, y, m, bc, ier)
 
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y
 end
 
 function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-    x::Real, bc::Int)
+                   x::Real, bc::Int)
     bc in (0, 1, 2, 3) || error("bc = $bc not in (0, 1, 2, 3)")
     y = Ref{Float64}(0)
     ier = Ref{Int32}(0)
     ccall((:splev_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32},
-            Ref{Float64}, Ref{Int32},
-            Ref{Float64}, Ref{Float64}, Ref{Int32},
-            Ref{Int32}, Ref{Int32}),
-        t, length(t), c, k, Float64(x), y, 1, bc, ier)
+         (Ref{Float64}, Ref{Int32},
+          Ref{Float64}, Ref{Int32},
+          Ref{Float64}, Ref{Float64}, Ref{Int32},
+          Ref{Int32}, Ref{Int32}),
+         t, length(t), c, k, Float64(x), y, 1, bc, ier)
 
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y[]
@@ -285,7 +290,7 @@ end
 
 evaluate(spline::Spline1D, x::AbstractVector) =
     _evaluate(spline.t, spline.c, spline.k,
-        convert(Vector{Float64}, x), spline.bc)
+              convert(Vector{Float64}, x), spline.bc)
 
 
 evaluate(spline::Spline1D, x::Real) =
@@ -293,36 +298,36 @@ evaluate(spline::Spline1D, x::Real) =
 
 
 function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-    x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64})
+                     x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64})
     (1 <= nu <= k) || error("order of derivative must be positive and less than or equal to spline order")
     m = length(x)
     n = length(t)
     y = Vector{Float64}(undef, m)
     ier = Ref{Int32}(0)
     ccall((:splder_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32}, # t, n
-            Ref{Float64}, Ref{Int32}, # c, k
-            Ref{Int32}, # nu
-            Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
-            Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
-        t, n, c, k, nu, x, y, m, bc, wrk, ier)
+         (Ref{Float64}, Ref{Int32}, # t, n
+          Ref{Float64}, Ref{Int32}, # c, k
+          Ref{Int32}, # nu
+          Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
+          Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
+         t, n, c, k, nu, x, y, m, bc, wrk, ier)
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y
 end
 
 function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-    x::Real, nu::Int, bc::Int, wrk::Vector{Float64})
+                     x::Real, nu::Int, bc::Int, wrk::Vector{Float64})
     (1 <= nu <= k) || error("order of derivative must be positive and less than or equal to spline order")
     n = length(t)
     y = Ref{Float64}(0)
     ier = Ref{Int32}(0)
     ccall((:splder_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32}, # t, n
-            Ref{Float64}, Ref{Int32}, # c, k
-            Ref{Int32}, # nu
-            Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
-            Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
-        t, n, c, k, nu, Float64(x), y, 1, bc, wrk, ier)
+         (Ref{Float64}, Ref{Int32}, # t, n
+          Ref{Float64}, Ref{Int32}, # c, k
+          Ref{Int32}, # nu
+          Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
+          Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
+         t, n, c, k, nu, Float64(x), y, 1, bc, wrk, ier)
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y[]
 end
@@ -331,29 +336,29 @@ end
 #       or should it be integrated with evaluate, above?
 #       (problem with that: derivative doesn't accept bc="nearest")
 # TODO: should `nu` be `d`?
-derivative(spline::Spline1D, x::AbstractVector, nu::Int = 1) =
+derivative(spline::Spline1D, x::AbstractVector, nu::Int=1) =
     _derivative(spline.t, spline.c, spline.k,
-        convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
+                convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
 
 
-derivative(spline::Spline1D, x::Real, nu::Int = 1) =
+derivative(spline::Spline1D, x::Real, nu::Int=1) =
     _derivative(spline.t, spline.c, spline.k, x, nu, spline.bc, spline.wrk)
 
 
 # TODO: deprecate this?
-derivative(spline::Spline1D, x; nu::Int = 1) = derivative(spline, x, nu)
+derivative(spline::Spline1D, x; nu::Int=1) = derivative(spline, x, nu)
 
 
 function _integrate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-    a::Real, b::Real, wrk::Vector{Float64})
+                    a::Real, b::Real, wrk::Vector{Float64})
     n = length(t)
     ccall((:splint_, libddierckx), Float64,
         (Ref{Float64}, Ref{Int32},
-            Ref{Float64}, Ref{Int32},
-            Ref{Float64}, Ref{Float64},
-            Ref{Float64}),
-        t, n, c, k,
-        Float64(a), Float64(b), wrk)
+         Ref{Float64}, Ref{Int32},
+         Ref{Float64}, Ref{Float64},
+         Ref{Float64}),
+         t, n, c, k,
+         Float64(a), Float64(b), wrk)
 end
 
 integrate(spline::Spline1D, a::Real, b::Real) =
@@ -361,7 +366,7 @@ integrate(spline::Spline1D, a::Real, b::Real) =
 
 # TODO roots for parametric splines
 # note: default maxn in scipy.interpolate is 3 * (length(spline.t) - 7)
-function roots(spline::Spline1D; maxn::Integer = 8)
+function roots(spline::Spline1D; maxn::Integer=8)
     if spline.k != 3
         error("root finding only supported for cubic splines (k=3)")
     end
@@ -370,12 +375,12 @@ function roots(spline::Spline1D; maxn::Integer = 8)
     m = Vector{Int32}(undef, 1)
     ier = Vector{Int32}(undef, 1)
     ccall((:sproot_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32},  # t, n
-            Ref{Float64}, Ref{Float64},  # c, zeros
-            Ref{Int32}, Ref{Int32},  # mest, m
-            Ref{Int32}),  # ier
-        spline.t, n, spline.c, zeros,
-        maxn, m, ier)
+          (Ref{Float64}, Ref{Int32},  # t, n
+           Ref{Float64}, Ref{Float64},  # c, zeros
+           Ref{Int32}, Ref{Int32},  # mest, m
+           Ref{Int32}),  # ier
+          spline.t, n, spline.c, zeros,
+          maxn, m, ier)
 
     if ier[1] == 0
         return zeros[1:m[1]]
@@ -418,42 +423,42 @@ end
 
 
 function ParametricSpline(x::AbstractMatrix;
-    w::AbstractVector = ones(size(x, 2)),
-    k::Int = 3, s::Real = 0.0, bc::AbstractString = "nearest",
-    periodic::Bool = false)
+                          w::AbstractVector=ones(size(x, 2)),
+                          k::Int=3, s::Real=0.0, bc::AbstractString="nearest",
+                          periodic::Bool=false)
     return _ParametricSpline(nothing, x, nothing, w, k, s, bc, periodic)
 end
 
 # version with user-supplied u
 function ParametricSpline(u::AbstractVector, x::AbstractMatrix;
-    ub::Real = u[1], ue::Real = u[end],
-    w::AbstractVector = ones(size(x, 2)),
-    k::Int = 3, s::Real = 0.0, bc::AbstractString = "nearest",
-    periodic::Bool = false)
+                          ub::Real=u[1], ue::Real=u[end],
+                          w::AbstractVector=ones(size(x, 2)),
+                          k::Int=3, s::Real=0.0, bc::AbstractString="nearest",
+                          periodic::Bool=false)
     return _ParametricSpline(u, x, nothing, w, k, s, bc, periodic)
 end
 
 # version with user-supplied knots
 function ParametricSpline(x::AbstractMatrix, knots::AbstractVector;
-    w::AbstractVector = ones(size(x, 2)),
-    k::Int = 3, bc::AbstractString = "nearest",
-    periodic::Bool = false)
+                          w::AbstractVector=ones(size(x, 2)),
+                          k::Int=3, bc::AbstractString="nearest",
+                          periodic::Bool=false)
     return _ParametricSpline(nothing, x, knots, w, k, -1.0, bc, periodic)
 end
 
 # version with user-supplied u and knots
 function ParametricSpline(u::AbstractVector, x::AbstractMatrix,
-    knots::AbstractVector;
-    w::AbstractVector = ones(size(x, 2)),
-    k::Int = 3, bc::AbstractString = "nearest",
-    periodic::Bool = false)
+                          knots::AbstractVector;
+                          w::AbstractVector=ones(size(x, 2)),
+                          k::Int=3, bc::AbstractString="nearest",
+                          periodic::Bool=false)
     return _ParametricSpline(u, x, knots, w, k, -1.0, bc, periodic)
 end
 
-function _ParametricSpline(u::Union{AbstractVector,Nothing}, x::AbstractMatrix,
-    knots::Union{AbstractVector,Nothing},
-    w::AbstractVector, k::Int, s::Real,
-    bc::AbstractString, periodic::Bool)
+function _ParametricSpline(u::Union{AbstractVector, Nothing}, x::AbstractMatrix,
+                           knots::Union{AbstractVector, Nothing},
+                           w::AbstractVector, k::Int, s::Real,
+                           bc::AbstractString, periodic::Bool)
     idim, m = size(x)
     if periodic
         x[:, 1] == x[:, end] || error("for periodic splines x[:,1] and x[:,end] must match")
@@ -500,82 +505,82 @@ function _ParametricSpline(u::Union{AbstractVector,Nothing}, x::AbstractMatrix,
     xin = convert(Matrix{Float64}, x)
     win = convert(Vector{Float64}, w)
     n = Ref{Int32}(nest)
-    c = Vector{Float64}(undef, idim * nest)
+    c = Vector{Float64}(undef, idim*nest)
     fp = Ref{Float64}(0)
     ier = Ref{Int32}(0)
 
     local lwrk::Int
     if periodic
-        lwrk = m * (k + 1) + nest * (7 + idim + 5k)
+        lwrk = m*(k + 1) + nest*(7 + idim + 5k)
     else
-        lwrk = m * (k + 1) + nest * (6 + idim + 3k)
+        lwrk = m*(k + 1) + nest*(6 + idim + 3k)
     end
     wrk = Vector{Float64}(undef, lwrk)
     iwrk = Vector{Int32}(undef, nest)
 
     if !periodic
         ccall((:parcur_, libddierckx), Nothing,
-            (Ref{Int32}, Ref{Int32}, # iopt, ipar
-                Ref{Int32}, Ref{Int32}, # idim, m
-                Ref{Float64}, Ref{Int32}, # u, mx
-                Ref{Float64}, Ref{Float64}, # x, w
-                Ref{Float64}, Ref{Float64}, # ub, ue
-                Ref{Int32}, Ref{Float64}, # k, s
-                Ref{Int32}, Ref{Int32}, # nest, n
-                Ref{Float64}, Ref{Int32}, # t, nc
-                Ref{Float64}, Ref{Float64}, # c, fp
-                Ref{Float64}, Ref{Int32}, # wrk, lwrk
-                Ref{Int32}, Ref{Int32}), #iwrk, ier
-            iopt, ipar,
-            idim, m,
-            uin, length(x),
-            xin, win,
-            ub, ue,
-            k, s,
-            nest, n,
-            t, length(c),
-            c, fp,
-            wrk, lwrk,
-            iwrk, ier)
+              (Ref{Int32}, Ref{Int32}, # iopt, ipar
+              Ref{Int32}, Ref{Int32}, # idim, m
+              Ref{Float64}, Ref{Int32}, # u, mx
+              Ref{Float64}, Ref{Float64}, # x, w
+              Ref{Float64}, Ref{Float64}, # ub, ue
+              Ref{Int32}, Ref{Float64}, # k, s
+              Ref{Int32}, Ref{Int32}, # nest, n
+              Ref{Float64}, Ref{Int32}, # t, nc
+              Ref{Float64}, Ref{Float64}, # c, fp
+              Ref{Float64}, Ref{Int32}, # wrk, lwrk
+              Ref{Int32}, Ref{Int32}), #iwrk, ier
+              iopt, ipar,
+              idim, m,
+              uin, length(x),
+              xin, win,
+              ub, ue,
+              k, s,
+              nest, n,
+              t, length(c),
+              c, fp,
+              wrk, lwrk,
+              iwrk, ier)
     else
         ccall((:clocur_, libddierckx), Nothing,
-            (Ref{Int32}, Ref{Int32}, # iopt, ipar
-                Ref{Int32}, Ref{Int32}, # idim, m
-                Ref{Float64}, Ref{Int32}, # u, mx
-                Ref{Float64}, Ref{Float64}, # x, w
-                Ref{Int32}, Ref{Float64}, # k, s
-                Ref{Int32}, Ref{Int32}, # nest, n
-                Ref{Float64}, Ref{Int32}, # t, nc
-                Ref{Float64}, Ref{Float64}, # c, fp
-                Ref{Float64}, Ref{Int32}, # wrk, lwrk
-                Ref{Int32}, Ref{Int32}), #iwrk, ier
-            iopt, ipar,
-            idim, m,
-            uin, length(x),
-            xin, win,
-            k, s,
-            nest, n,
-            t, length(c),
-            c, fp,
-            wrk, lwrk,
-            iwrk, ier)
+              (Ref{Int32}, Ref{Int32}, # iopt, ipar
+              Ref{Int32}, Ref{Int32}, # idim, m
+              Ref{Float64}, Ref{Int32}, # u, mx
+              Ref{Float64}, Ref{Float64}, # x, w
+              Ref{Int32}, Ref{Float64}, # k, s
+              Ref{Int32}, Ref{Int32}, # nest, n
+              Ref{Float64}, Ref{Int32}, # t, nc
+              Ref{Float64}, Ref{Float64}, # c, fp
+              Ref{Float64}, Ref{Int32}, # wrk, lwrk
+              Ref{Int32}, Ref{Int32}), #iwrk, ier
+              iopt, ipar,
+              idim, m,
+              uin, length(x),
+              xin, win,
+              k, s,
+              nest, n,
+              t, length(c),
+              c, fp,
+              wrk, lwrk,
+              iwrk, ier)
     end
 
     ier[] <= 0 || error(_fit1d_messages[ier[]])
 
     resize!(t, n[])
-    c = [c[n[]*(j-1)+i] for j = 1:idim, i = 1:n[]-k-1]
+    c = [c[n[]*(j-1) + i] for j=1:idim, i=1:n[]-k-1]
 
     return ParametricSpline(t, c, k, _translate_bc(bc), fp[])
 end
 
 _evaluate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-    x::Vector{Float64}, bc::Int) =
-    mapslices(v -> _evaluate(t, v, k, x, bc), c, dims = [2])
+          x::Vector{Float64}, bc::Int) =
+    mapslices(v -> _evaluate(t, v, k, x, bc), c, dims=[2])
 
 _evaluate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-    x::Real, bc::Int) =
-    vec(mapslices(v -> _evaluate(t, v, k, x, bc), c, dims = [2]))
+          x::Real, bc::Int) =
+    vec(mapslices(v -> _evaluate(t, v, k, x, bc), c, dims=[2]))
 
 function evaluate(spline::ParametricSpline, x::AbstractVector)
     xin = convert(Vector{Float64}, x)
@@ -586,26 +591,26 @@ evaluate(spline::ParametricSpline, x::Real) =
     _evaluate(spline.t, spline.c, spline.k, x, spline.bc)
 
 _derivative(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-    x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64}) =
-    mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims = [2])
+            x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64}) =
+    mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims=[2])
 
 _derivative(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-    x::Real, nu::Int, bc::Int, wrk::Vector{Float64}) =
-    vec(mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims = [2]))
+            x::Real, nu::Int, bc::Int, wrk::Vector{Float64}) =
+    vec(mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims=[2]))
 
-derivative(spline::ParametricSpline, x::AbstractVector, nu::Int = 1) =
+derivative(spline::ParametricSpline, x::AbstractVector, nu::Int=1) =
     _derivative(spline.t, spline.c, spline.k,
-        convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
+                convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
 
 # TODO: deprecate this
-derivative(spline::ParametricSpline, x; nu::Int = 1) = derivative(spline, x, nu)
+derivative(spline::ParametricSpline, x; nu::Int=1) = derivative(spline, x, nu)
 
-derivative(spline::ParametricSpline, x::Real, nu::Int = 1) =
+derivative(spline::ParametricSpline, x::Real, nu::Int=1) =
     _derivative(spline.t, spline.c, spline.k, x, nu, spline.bc, spline.wrk)
 
 _integrate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-    a::Real, b::Real, wrk::Vector{Float64}) =
-    vec(mapslices(v -> _integrate(t, v, k, a, b, wrk), c, dims = [2]))
+           a::Real, b::Real, wrk::Vector{Float64}) =
+    vec(mapslices(v -> _integrate(t, v, k, a, b, wrk), c, dims=[2]))
 
 integrate(spline::ParametricSpline, a::Real, b::Real) =
     _integrate(spline.t, spline.c, spline.k, a, b, spline.wrk)
@@ -620,45 +625,62 @@ integrate(spline::ParametricSpline, a::Real, b::Real) =
 # swapped with regard to what the Fortran documentation says.
 
 const _fit2d_messages = Dict(
-    -3 =>
-    """The coefficients of the spline returned have been computed as the
-    minimal norm least-squares solution of a (numerically) rank deficient
-    system (deficiency=%i). If deficiency is large, the results may be
-    inaccurate. Deficiency may strongly depend on the value of eps.""", 1 =>
-    """The required storage space exceeds the available storage space:
-    nxest or nyest too small, or s too small. Try increasing s.""",
-    # The weighted least-squares spline corresponds to the current set of knots.
+-3=>
 
-    2 =>
-    """A theoretically impossible result was found during the iteration
-    process for finding a smoothing spline with fp = s: s too small or
-    badly chosen eps.  Weighted sum of squared residuals does not satisfy
-    abs(fp-s)/s < tol.""", 3 =>
-    """the maximal number of iterations maxit (set to 20 by the program)
-    allowed for finding a smoothing spline with fp=s has been reached: s
-    too small.  Weighted sum of squared residuals does not satisfy
-    abs(fp-s)/s < tol.""", 4 =>
-    """No more knots can be added because the number of b-spline
-    coefficients (nx-kx-1)*(ny-ky-1) already exceeds the number of data
-    points m: either s or m too small.  The weighted least-squares spline
-    corresponds to the current set of knots.""", 5 =>
-    """No more knots can be added because the additional knot would
-    (quasi) coincide with an old one: s too small or too large a weight to
-    an inaccurate data point.  The weighted least-squares spline
-    corresponds to the current set of knots.""", 10 =>
-    """Error on entry, no approximation returned. The following conditions
-    must hold:
-    xb<=x[i]<=xe, yb<=y[i]<=ye, w[i]>0, i=0..m-1
-    If iopt==-1, then
-      xb<tx[kx+1]<tx[kx+2]<...<tx[nx-kx-2]<xe
-      yb<ty[ky+1]<ty[ky+2]<...<ty[ny-ky-2]<ye""")
+"""The coefficients of the spline returned have been computed as the
+minimal norm least-squares solution of a (numerically) rank deficient
+system (deficiency=%i). If deficiency is large, the results may be
+inaccurate. Deficiency may strongly depend on the value of eps.""",
+
+1=>
+
+"""The required storage space exceeds the available storage space:
+nxest or nyest too small, or s too small. Try increasing s.""",
+# The weighted least-squares spline corresponds to the current set of knots.
+
+2=>
+
+"""A theoretically impossible result was found during the iteration
+process for finding a smoothing spline with fp = s: s too small or
+badly chosen eps.  Weighted sum of squared residuals does not satisfy
+abs(fp-s)/s < tol.""",
+
+3=>
+
+"""the maximal number of iterations maxit (set to 20 by the program)
+allowed for finding a smoothing spline with fp=s has been reached: s
+too small.  Weighted sum of squared residuals does not satisfy
+abs(fp-s)/s < tol.""",
+
+4=>
+
+"""No more knots can be added because the number of b-spline
+coefficients (nx-kx-1)*(ny-ky-1) already exceeds the number of data
+points m: either s or m too small.  The weighted least-squares spline
+corresponds to the current set of knots.""",
+
+5=>
+
+"""No more knots can be added because the additional knot would
+(quasi) coincide with an old one: s too small or too large a weight to
+an inaccurate data point.  The weighted least-squares spline
+corresponds to the current set of knots.""",
+
+10=>
+
+"""Error on entry, no approximation returned. The following conditions
+must hold:
+xb<=x[i]<=xe, yb<=y[i]<=ye, w[i]>0, i=0..m-1
+If iopt==-1, then
+  xb<tx[kx+1]<tx[kx+2]<...<tx[nx-kx-2]<xe
+  yb<ty[ky+1]<ty[ky+2]<...<ty[ny-ky-2]<ye""")
 
 const _eval2d_message = (
-    """Invalid input data. Restrictions:
-    length(x) != 0, length(y) != 0
-    x[i-1] <= x[i] for i=2,...,length(x)
-    y[j-1] <= y[j] for j=2,...,length(y)
-    """)
+"""Invalid input data. Restrictions:
+length(x) != 0, length(y) != 0
+x[i-1] <= x[i] for i=2,...,length(x)
+y[j-1] <= y[j] for j=2,...,length(y)
+""")
 
 mutable struct Spline2D
     tx::Vector{Float64}
@@ -670,7 +692,7 @@ mutable struct Spline2D
 end
 
 get_knots(spl::Spline2D) = (spl.tx[spl.kx+1:end-spl.kx],
-    spl.ty[spl.ky+1:end-spl.ky])
+                            spl.ty[spl.ky+1:end-spl.ky])
 get_residual(spl::Spline2D) = spl.fp
 
 function ==(s1::Spline2D, s2::Spline2D)
@@ -685,17 +707,17 @@ function calc_surfit_lwrk1(m, kx, ky, nxest, nyest)
     v = nyest - ky - 1
     km = max(kx, ky) + 1
     ne = max(nxest, nyest)
-    bx = kx * v + ky + 1
-    by = ky * u + kx + 1
+    bx = kx*v + ky + 1
+    by = ky*u + kx + 1
     b1 = b2 = 0
-    if (bx <= by)
+    if (bx<=by)
         b1 = bx
         b2 = bx + v - ky
     else
         b1 = by
         b2 = by + u - kx
     end
-    return u * v * (2 + b1 + b2) + 2 * (u + v + km * (m + ne) + ne - kx - ky) + b2 + 1
+    return u*v*(2 + b1 + b2) + 2*(u+v+km*(m+ne)+ne-kx-ky) + b2 + 1
 end
 
 function calc_surfit_lwrk2(m, kx, ky, nxest, nyest)
@@ -709,16 +731,16 @@ end
 
 # Construct spline from unstructured data
 function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
-    w::AbstractVector = ones(length(x)), kx::Int = 3, ky::Int = 3,
-    s::Real = 0.0)
+                  w::AbstractVector=ones(length(x)), kx::Int=3, ky::Int=3,
+                  s::Real=0.0)
 
     # array sizes
     m = length(x)
     (length(y) == length(z) == m) || error("lengths of x, y, z must match")
     (length(w) == m) || error("length of w must match other inputs")
 
-    nxest = max(kx + 1 + ceil(Int, sqrt(m / 2)), 2 * (kx + 1))
-    nyest = max(ky + 1 + ceil(Int, sqrt(m / 2)), 2 * (ky + 1))
+    nxest = max(kx+1+ceil(Int,sqrt(m/2)), 2*(kx+1))
+    nyest = max(ky+1+ceil(Int,sqrt(m/2)), 2*(ky+1))
     nmax = max(nxest, nyest)
 
     eps = 1.0e-16
@@ -740,7 +762,7 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
     tx = Vector{Float64}(undef, nxest)
     ny = Ref{Int32}()
     ty = Vector{Float64}(undef, nyest)
-    c = Vector{Float64}(undef, (nxest - kx - 1) * (nyest - ky - 1))
+    c = Vector{Float64}(undef, (nxest-kx-1) * (nyest-ky-1))
     fp = Ref{Float64}()
     ier = Ref{Int32}()
 
@@ -748,29 +770,29 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
     # Note: in lwrk1 and lwrk2, x and y are swapped on purpose.
     lwrk1 = calc_surfit_lwrk1(m, ky, kx, nyest, nxest)
     lwrk2 = calc_surfit_lwrk2(m, ky, kx, nyest, nxest)
-    kwrk = m + (nxest - 2 * kx - 1) * (nyest - 2 * ky - 1)
+    kwrk = m + (nxest - 2*kx - 1) * (nyest - 2*ky - 1)
     wrk1 = Vector{Float64}(undef, lwrk1)
     wrk2 = Vector{Float64}(undef, lwrk2)
     iwrk = Vector{Int32}(undef, kwrk)
 
     ccall((:surfit_, libddierckx), Nothing,
-        (Ref{Int32}, Ref{Int32},  # iopt, m
-            Ref{Float64}, Ref{Float64},  # y, x
-            Ref{Float64}, Ref{Float64},  # z, w
-            Ref{Float64}, Ref{Float64},  # yb, ye
-            Ref{Float64}, Ref{Float64},  # xb, xe
-            Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
-            Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
-            Ref{Float64},  # eps
-            Ref{Int32}, Ref{Float64},  # ny, tx
-            Ref{Int32}, Ref{Float64},  # nx, tx
-            Ref{Float64}, Ref{Float64},  # c, fp
-            Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
-            Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
-            Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
-        0, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx,
-        Float64(s), nyest, nxest, nmax, eps, ny, ty, nx, tx,
-        c, fp, wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
+          (Ref{Int32}, Ref{Int32},  # iopt, m
+           Ref{Float64}, Ref{Float64},  # y, x
+           Ref{Float64}, Ref{Float64},  # z, w
+           Ref{Float64}, Ref{Float64},  # yb, ye
+           Ref{Float64}, Ref{Float64},  # xb, xe
+           Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
+           Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
+           Ref{Float64},  # eps
+           Ref{Int32}, Ref{Float64},  # ny, tx
+           Ref{Int32}, Ref{Float64},  # nx, tx
+           Ref{Float64}, Ref{Float64},  # c, fp
+           Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
+           Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
+           Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
+          0, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx,
+          Float64(s), nyest, nxest, nmax, eps, ny, ty, nx, tx,
+          c, fp, wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
 
     while ier[] > 10
         # lwrk2 is too small, i.e., there is not enough workspace
@@ -781,23 +803,23 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
         lwrk2 = ier[]
         resize!(wrk2, lwrk2)
         ccall((:surfit_, libddierckx), Nothing,
-            (Ref{Int32}, Ref{Int32},  # iopt, m
-                Ref{Float64}, Ref{Float64},  # y, x
-                Ref{Float64}, Ref{Float64},  # z, w
-                Ref{Float64}, Ref{Float64},  # yb, ye
-                Ref{Float64}, Ref{Float64},  # xb, xe
-                Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
-                Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
-                Ref{Float64},  # eps
-                Ref{Int32}, Ref{Float64},  # ny, tx
-                Ref{Int32}, Ref{Float64},  # nx, tx
-                Ref{Float64}, Ref{Float64},  # c, fp
-                Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
-                Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
-                Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
-            1, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx, s,
-            nyest, nxest, nmax, eps, ny, ty, nx, tx, c, fp,
-            wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
+              (Ref{Int32}, Ref{Int32},  # iopt, m
+               Ref{Float64}, Ref{Float64},  # y, x
+               Ref{Float64}, Ref{Float64},  # z, w
+               Ref{Float64}, Ref{Float64},  # yb, ye
+               Ref{Float64}, Ref{Float64},  # xb, xe
+               Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
+               Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
+               Ref{Float64},  # eps
+               Ref{Int32}, Ref{Float64},  # ny, tx
+               Ref{Int32}, Ref{Float64},  # nx, tx
+               Ref{Float64}, Ref{Float64},  # c, fp
+               Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
+               Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
+               Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
+              1, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx, s,
+              nyest, nxest, nmax, eps, ny, ty, nx, tx, c, fp,
+              wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
     end
 
     if (ier[] == 0 || ier[] == -1 || ier[] == -2)
@@ -828,7 +850,7 @@ end
 
 # Construct spline from data on a grid.
 function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
-    kx::Int = 3, ky::Int = 3, s::Real = 0.0)
+                  kx::Int=3, ky::Int=3, s::Real=0.0)
     mx = length(x)
     my = length(y)
     @assert size(z, 1) == mx && size(z, 2) == my
@@ -841,8 +863,8 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
     xe = x[end]
     yb = y[1]
     ye = y[end]
-    nxest = mx + kx + 1
-    nyest = my + ky + 1
+    nxest = mx+kx+1
+    nyest = my+ky+1
 
     # ensure arrays are of correct type
     xin = convert(Vector{Float64}, x)
@@ -854,37 +876,37 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
     tx = Vector{Float64}(undef, nxest)
     ny = Ref{Int32}()
     ty = Vector{Float64}(undef, nyest)
-    c = Vector{Float64}(undef, (nxest - kx - 1) * (nyest - ky - 1))
+    c = Vector{Float64}(undef, (nxest-kx-1) * (nyest-ky-1))
     fp = Ref{Float64}()
     ier = Ref{Int32}()
 
     # Work arrays.
     # Note that in lwrk, x and y are swapped with respect to the Fortran
     # documentation. See "NOTE REGARDING ARGUMENT ORDER" above.
-    lwrk = (4 + nyest * (mx + 2 * ky + 5) + nxest * (2 * kx + 5) +
-            my * (ky + 1) + mx * (kx + 1) + max(mx, nyest))
+    lwrk = (4 + nyest * (mx+2*ky+5) + nxest * (2*kx+5) +
+            my*(ky+1) + mx*(kx+1) + max(mx, nyest))
     wrk = Vector{Float64}(undef, lwrk)
     kwrk = 3 + mx + my + nxest + nyest
     iwrk = Vector{Int32}(undef, kwrk)
 
     ccall((:regrid_, libddierckx), Nothing,
-        (Ref{Int32},  # iopt
-            Ref{Int32}, Ref{Float64},  # my, y
-            Ref{Int32}, Ref{Float64},  # mx, x
-            Ref{Float64},  # z
-            Ref{Float64}, Ref{Float64},  # yb, ye
-            Ref{Float64}, Ref{Float64},  # xb, xe
-            Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
-            Ref{Int32}, Ref{Int32},  # nyest, nxest
-            Ref{Int32}, Ref{Float64},  # ny, ty
-            Ref{Int32}, Ref{Float64},  # nx, tx
-            Ref{Float64}, Ref{Float64},  # c, fp
-            Ref{Float64}, Ref{Int32},  # wrk, lwrk
-            Ref{Int32}, Ref{Int32},  # iwrk, lwrk
-            Ref{Int32}),  # ier
-        0.0f0, my, yin, mx, xin, zin, yb, ye, xb, xe, ky, kx,
-        Float64(s), nyest, nxest, ny, ty, nx, tx, c, fp,
-        wrk, lwrk, iwrk, kwrk, ier)
+          (Ref{Int32},  # iopt
+           Ref{Int32}, Ref{Float64},  # my, y
+           Ref{Int32}, Ref{Float64},  # mx, x
+           Ref{Float64},  # z
+           Ref{Float64}, Ref{Float64},  # yb, ye
+           Ref{Float64}, Ref{Float64},  # xb, xe
+           Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
+           Ref{Int32}, Ref{Int32},  # nyest, nxest
+           Ref{Int32}, Ref{Float64},  # ny, ty
+           Ref{Int32}, Ref{Float64},  # nx, tx
+           Ref{Float64}, Ref{Float64},  # c, fp
+           Ref{Float64}, Ref{Int32},  # wrk, lwrk
+           Ref{Int32}, Ref{Int32},  # iwrk, lwrk
+           Ref{Int32}),  # ier
+          0f0, my, yin, mx, xin, zin, yb, ye, xb, xe, ky, kx,
+          Float64(s), nyest, nxest, ny, ty, nx, tx, c, fp,
+          wrk, lwrk, iwrk, kwrk, ier)
 
     if !(ier[] == 0 || ier[] == -1 || ier[] == -2)
         error(_fit2d_messages[ier[]])
@@ -913,17 +935,17 @@ function evaluate(spline::Spline2D, x::AbstractVector, y::AbstractVector)
     z = Vector{Float64}(undef, m)
 
     ccall((:bispeu_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32},  # ty, ny
-            Ref{Float64}, Ref{Int32},  # tx, nx
-            Ref{Float64},  # c
-            Ref{Int32}, Ref{Int32},  # ky, kx
-            Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
-            Ref{Int32},  # m
-            Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
-        spline.ty, length(spline.ty),
-        spline.tx, length(spline.tx),
-        spline.c, spline.ky, spline.kx, yin, xin, z, m,
-        wrk, lwrk, ier)
+          (Ref{Float64}, Ref{Int32},  # ty, ny
+           Ref{Float64}, Ref{Int32},  # tx, nx
+           Ref{Float64},  # c
+           Ref{Int32}, Ref{Int32},  # ky, kx
+           Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
+           Ref{Int32},  # m
+           Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
+          spline.ty, length(spline.ty),
+          spline.tx, length(spline.tx),
+          spline.c, spline.ky, spline.kx, yin, xin, z, m,
+          wrk, lwrk, ier)
 
     ier[] == 0 || error(_eval2d_message)
 
@@ -936,17 +958,17 @@ function evaluate(spline::Spline2D, x::Real, y::Real)
     wrk = Vector{Float64}(undef, lwrk)
     z = Ref{Float64}()
     ccall((:bispeu_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32},  # ty, ny
-            Ref{Float64}, Ref{Int32},  # tx, nx
-            Ref{Float64},  # c
-            Ref{Int32}, Ref{Int32},  # ky, kx
-            Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
-            Ref{Int32},  # m
-            Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
-        spline.ty, length(spline.ty),
-        spline.tx, length(spline.tx),
-        spline.c, spline.ky, spline.kx, y, x, z, 1,
-        wrk, lwrk, ier)
+          (Ref{Float64}, Ref{Int32},  # ty, ny
+           Ref{Float64}, Ref{Int32},  # tx, nx
+           Ref{Float64},  # c
+           Ref{Int32}, Ref{Int32},  # ky, kx
+           Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
+           Ref{Int32},  # m
+           Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
+          spline.ty, length(spline.ty),
+          spline.tx, length(spline.tx),
+          spline.c, spline.ky, spline.kx, y, x, z, 1,
+          wrk, lwrk, ier)
 
     ier[] == 0 || error(_eval2d_message)
     return z[]
@@ -960,7 +982,7 @@ function evalgrid(spline::Spline2D, x::AbstractVector, y::AbstractVector)
     xin = convert(Vector{Float64}, x)
     yin = convert(Vector{Float64}, y)
 
-    lwrk = mx * (spline.kx + 1) + my * (spline.ky + 1)
+    lwrk = mx*(spline.kx + 1) + my*(spline.ky + 1)
     wrk = Vector{Float64}(undef, lwrk)
     kwrk = mx + my
     iwrk = Vector{Int32}(undef, kwrk)
@@ -968,20 +990,20 @@ function evalgrid(spline::Spline2D, x::AbstractVector, y::AbstractVector)
     z = Matrix{Float64}(undef, mx, my)
 
     ccall((:bispev_, libddierckx), Nothing,
-        (Ref{Float64}, Ref{Int32},  # ty, ny
-            Ref{Float64}, Ref{Int32},  # tx, nx
-            Ref{Float64},  # c
-            Ref{Int32}, Ref{Int32},  # ky, kx
-            Ref{Float64}, Ref{Int32},  # y, my
-            Ref{Float64}, Ref{Int32},  # x, mx
-            Ref{Float64},  # z
-            Ref{Float64}, Ref{Int32},  # wrk, lwrk
-            Ref{Int32}, Ref{Int32},  # iwrk, kwrk
-            Ref{Int32}),  # ier
-        spline.ty, length(spline.ty),
-        spline.tx, length(spline.tx),
-        spline.c, spline.ky, spline.kx, yin, my, xin, mx, z,
-        wrk, lwrk, iwrk, kwrk, ier)
+          (Ref{Float64}, Ref{Int32},  # ty, ny
+           Ref{Float64}, Ref{Int32},  # tx, nx
+           Ref{Float64},  # c
+           Ref{Int32}, Ref{Int32},  # ky, kx
+           Ref{Float64}, Ref{Int32},  # y, my
+           Ref{Float64}, Ref{Int32},  # x, mx
+           Ref{Float64},  # z
+           Ref{Float64}, Ref{Int32},  # wrk, lwrk
+           Ref{Int32}, Ref{Int32},  # iwrk, kwrk
+           Ref{Int32}),  # ier
+          spline.ty, length(spline.ty),
+          spline.tx, length(spline.tx),
+          spline.c, spline.ky, spline.kx, yin, my, xin, mx, z,
+          wrk, lwrk, iwrk, kwrk, ier)
 
     ier[] == 0 || error(_eval2d_message)
 
@@ -1062,28 +1084,28 @@ end
 
 # 2D integration
 function integrate(spline::Spline2D, xb::Real, xe::Real, yb::Real, ye::Real)
-    nx = length(spline.tx)
-    ny = length(spline.ty)
+        nx = length(spline.tx)
+        ny = length(spline.ty)
 
-    kx = spline.kx
-    ky = spline.ky
+        kx = spline.kx
+        ky = spline.ky
 
-    wrk = Vector{Float64}(undef, nx + ny - kx - ky - 2)
-    ccall((:dblint_, libddierckx), Float64,
-        (Ref{Float64}, Ref{Int32},  # tx, nx
-            Ref{Float64}, Ref{Int32},  # ty, ny
-            Ref{Float64}, Ref{Int32},  # c, kx
-            Ref{Int32}, #ky
-            Ref{Float64}, Ref{Float64},  # xb, xe
-            Ref{Float64}, Ref{Float64},  # yb, ye
-            Ref{Float64}),  # wrk
-        spline.tx, nx,
-        spline.ty, ny,
-        spline.c, spline.kx,
-        spline.ky,
-        xb, xe,
-        yb, ye,
-        wrk)
+        wrk = Vector{Float64}(undef, nx + ny -kx - ky -2)
+        ccall((:dblint_, libddierckx), Float64,
+              (Ref{Float64}, Ref{Int32},  # tx, nx
+               Ref{Float64}, Ref{Int32},  # ty, ny
+               Ref{Float64}, Ref{Int32},  # c, kx
+               Ref{Int32}, #ky
+               Ref{Float64}, Ref{Float64},  # xb, xe
+               Ref{Float64}, Ref{Float64},  # yb, ye
+               Ref{Float64}),  # wrk
+              spline.tx, nx,
+              spline.ty, ny,
+              spline.c, spline.kx,
+              spline.ky,
+              xb, xe,
+              yb, ye,
+              wrk)
 end
 
 # call synonyms for evaluate():

--- a/src/Dierckx.jl
+++ b/src/Dierckx.jl
@@ -3,16 +3,16 @@ module Dierckx
 using Dierckx_jll
 
 export Spline1D,
-       Spline2D,
-       ParametricSpline,
-       evaluate,
-       derivative,
-       integrate,
-       roots,
-       evalgrid,
-       get_knots,
-       get_coeffs,
-       get_residual
+    Spline2D,
+    ParametricSpline,
+    evaluate,
+    derivative,
+    integrate,
+    roots,
+    evalgrid,
+    get_knots,
+    get_coeffs,
+    get_residual
 
 import Base: show, ==
 
@@ -20,44 +20,39 @@ import Base: show, ==
 # 1-d splines
 
 const _fit1d_messages = Dict(
-2=>
-"""A theoretically impossible result was found during the iteration
-process for finding a smoothing spline with fp = s: s too small.
-There is an approximation returned but the corresponding weighted sum
-of squared residuals does not satisfy the condition abs(fp-s)/s <
-tol.""",
-3=>
-"""The maximal number of iterations maxit (set to 20 by the program)
-allowed for finding a smoothing spline with fp=s has been reached: s
-too small. There is an approximation returned but the corresponding
-weighted sum of squared residuals does not satisfy the condition
-abs(fp-s)/s < tol.""",
-10=>
-"""Error on entry, no approximation returned. The following conditions
-must hold:
-1<=k<=5
-x[1] < x[2] < ... < x[end]
-w[i] > 0.0 for all i
+    2 => """A theoretically impossible result was found during the iteration
+         process for finding a smoothing spline with fp = s: s too small.
+         There is an approximation returned but the corresponding weighted sum
+         of squared residuals does not satisfy the condition abs(fp-s)/s <
+         tol.""",
+    3 => """The maximal number of iterations maxit (set to 20 by the program)
+         allowed for finding a smoothing spline with fp=s has been reached: s
+         too small. There is an approximation returned but the corresponding
+         weighted sum of squared residuals does not satisfy the condition
+         abs(fp-s)/s < tol.""",
+    10 => """Error on entry, no approximation returned. The following conditions
+          must hold:
+          1<=k<=5
+          x[1] < x[2] < ... < x[end]
+          w[i] > 0.0 for all i
 
-Additionally, if spline knots are given:
-length(xknots) <= length(x) + k + 1
-x[1] < xknots[1] < xknots[k+2] < ... < xknots[end] < x[end]
-The schoenberg-whitney conditions: there must be a subset of data points
-xx[j] such that t[j] < xx[j] < t[j+k+1] for j=1,2,...,n-k-1""")
+          Additionally, if spline knots are given:
+          length(xknots) <= length(x) + k + 1
+          x[1] < xknots[1] < xknots[k+2] < ... < xknots[end] < x[end]
+          The schoenberg-whitney conditions: there must be a subset of data points
+          xx[j] such that t[j] < xx[j] < t[j+k+1] for j=1,2,...,n-k-1""")
 
 
 const _eval1d_messages = Dict(
-1=>
-"""Input point out of range""",
-10=>
-"""Invalid input data. The following conditions must hold:
-length(x) != 0 and xb <= x[1] <= x[2] <= ... x[end] <= xe""")
+    1 => """Input point out of range""",
+    10 => """Invalid input data. The following conditions must hold:
+          length(x) != 0 and xb <= x[1] <= x[2] <= ... x[end] <= xe""")
 
 _translate_bc(bc::AbstractString) = (bc == "extrapolate" ? 0 :
-                             bc == "zero" ? 1 :
-                             bc == "error" ? 2 :
-                             bc == "nearest" ? 3 :
-                             error("unknown boundary condition: \"$bc\""))
+                                     bc == "zero" ? 1 :
+                                     bc == "error" ? 2 :
+                                     bc == "nearest" ? 3 :
+                                     error("unknown boundary condition: \"$bc\""))
 _translate_bc(bc::Int) = (bc == 0 ? "extrapolate" :
                           bc == 1 ? "zero" :
                           bc == 2 ? "error" :
@@ -109,9 +104,9 @@ function show(io::IO, spl::Spline1D)
 end
 
 function Spline1D(x::AbstractVector, y::AbstractVector;
-                  w::AbstractVector=ones(length(x)),
-                  k::Int=3, s::Real=0.0, bc::AbstractString="nearest",
-                  periodic::Bool=false)
+    w::AbstractVector = ones(length(x)),
+    k::Int = 3, s::Real = 0.0, bc::AbstractString = "nearest",
+    periodic::Bool = false)
     m = length(x)
     length(y) == m || error("length of x and y must match")
     length(w) == m || error("length of x and w must match")
@@ -140,9 +135,9 @@ function Spline1D(x::AbstractVector, y::AbstractVector;
     # workspace
     lwrk = 0
     if periodic
-        lwrk = m * (k + 1) + nest*(8 + 5k)
+        lwrk = m * (k + 1) + nest * (8 + 5k)
     else
-        lwrk = m * (k + 1) + nest*(7 + 3k)
+        lwrk = m * (k + 1) + nest * (7 + 3k)
     end
     wrk = Vector{Float64}(undef, lwrk)
     iwrk = Vector{Int32}(undef, nest)
@@ -150,24 +145,24 @@ function Spline1D(x::AbstractVector, y::AbstractVector;
     if !periodic
         ccall((:curfit_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32},  # iopt, m
-             Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
-             Ref{Float64}, Ref{Float64},  # xb, xe
-             Ref{Int32}, Ref{Float64},  # k, s
-             Ref{Int32}, Ref{Int32}, # nest, n
-             Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
-             Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
-             Ref{Int32}),  # ier
+                Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
+                Ref{Float64}, Ref{Float64},  # xb, xe
+                Ref{Int32}, Ref{Float64},  # k, s
+                Ref{Int32}, Ref{Int32}, # nest, n
+                Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
+                Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
+                Ref{Int32}),  # ier
             0, m, xin, yin, win, xin[1], xin[end], k, Float64(s),
             nest, n, t, c, fp, wrk, lwrk, iwrk, ier)
     else
         ccall((:percur_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32}, # iopt, m
-             Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
-             Ref{Int32}, Ref{Float64}, # k, s
-             Ref{Int32}, Ref{Int32}, # nest, n
-             Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
-             Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
-             Ref{Int32}), # ier
+                Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
+                Ref{Int32}, Ref{Float64}, # k, s
+                Ref{Int32}, Ref{Int32}, # nest, n
+                Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
+                Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
+                Ref{Int32}), # ier
             0, m, xin, yin, win, k, Float64(s), nest, n, t, c,
             fp, wrk, lwrk, iwrk, ier)
     end
@@ -183,10 +178,10 @@ end
 
 # version with user-supplied knots
 function Spline1D(x::AbstractVector, y::AbstractVector,
-                  knots::AbstractVector;
-                  w::AbstractVector=ones(length(x)),
-                  k::Int=3, bc::AbstractString="nearest",
-                  periodic::Bool=false)
+    knots::AbstractVector;
+    w::AbstractVector = ones(length(x)),
+    k::Int = 3, bc::AbstractString = "nearest",
+    periodic::Bool = false)
     m = length(x)
     length(y) == m || error("length of x and y must match")
     length(w) == m || error("length of x and w must match")
@@ -214,9 +209,9 @@ function Spline1D(x::AbstractVector, y::AbstractVector,
     # workspace
     lwrk = 0
     if periodic
-        lwrk = m * (k + 1) + n*(8 + 5k)
+        lwrk = m * (k + 1) + n * (8 + 5k)
     else
-        lwrk = m * (k + 1) + n*(7 + 3k)
+        lwrk = m * (k + 1) + n * (7 + 3k)
     end
     wrk = Vector{Float64}(undef, lwrk)
     iwrk = Vector{Int32}(undef, n)
@@ -224,24 +219,24 @@ function Spline1D(x::AbstractVector, y::AbstractVector,
     if !periodic
         ccall((:curfit_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32},  # iopt, m
-             Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
-             Ref{Float64}, Ref{Float64},  # xb, xe
-             Ref{Int32}, Ref{Float64},  # k, s
-             Ref{Int32}, Ref{Int32}, # nest, n
-             Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
-             Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
-             Ref{Int32}),  # ier
+                Ref{Float64}, Ref{Float64}, Ref{Float64},  # x, y, w
+                Ref{Float64}, Ref{Float64},  # xb, xe
+                Ref{Int32}, Ref{Float64},  # k, s
+                Ref{Int32}, Ref{Int32}, # nest, n
+                Ref{Float64}, Ref{Float64}, Ref{Float64},  # t, c, fp
+                Ref{Float64}, Ref{Int32}, Ref{Int32},  # wrk, lwrk, iwrk
+                Ref{Int32}),  # ier
             -1, m, xin, yin, win, xin[1], xin[end], k, -1.0,
             n, n, t, c, fp, wrk, lwrk, iwrk, ier)
     else
         ccall((:percur_, libddierckx), Nothing,
             (Ref{Int32}, Ref{Int32}, # iopt, m
-             Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
-             Ref{Int32}, Ref{Float64}, # k, s
-             Ref{Int32}, Ref{Int32}, # nest, n
-             Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
-             Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
-             Ref{Int32}), # ier
+                Ref{Float64}, Ref{Float64}, Ref{Float64}, # x, y, w
+                Ref{Int32}, Ref{Float64}, # k, s
+                Ref{Int32}, Ref{Int32}, # nest, n
+                Ref{Float64}, Ref{Float64}, Ref{Float64}, # t, c, fp
+                Ref{Float64}, Ref{Int32}, Ref{Int32}, # wrk, lwrk, iwrk
+                Ref{Int32}), # ier
             -1, m, xin, yin, win, k, -1.0, n, n, t, c,
             fp, wrk, lwrk, iwrk, ier)
     end
@@ -254,34 +249,34 @@ end
 
 
 function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                   x::Vector{Float64}, bc::Int)
+    x::Vector{Float64}, bc::Int)
     bc in (0, 1, 2, 3) || error("bc = $bc not in (0, 1, 2, 3)")
     m = length(x)
     xin = convert(Vector{Float64}, x)
     y = Vector{Float64}(undef, m)
     ier = Ref{Int32}(0)
     ccall((:splev_, libddierckx), Nothing,
-         (Ref{Float64}, Ref{Int32},
-          Ref{Float64}, Ref{Int32},
-          Ref{Float64}, Ref{Float64}, Ref{Int32},
-          Ref{Int32}, Ref{Int32}),
-         t, length(t), c, k, xin, y, m, bc, ier)
+        (Ref{Float64}, Ref{Int32},
+            Ref{Float64}, Ref{Int32},
+            Ref{Float64}, Ref{Float64}, Ref{Int32},
+            Ref{Int32}, Ref{Int32}),
+        t, length(t), c, k, xin, y, m, bc, ier)
 
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y
 end
 
 function _evaluate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                   x::Real, bc::Int)
+    x::Real, bc::Int)
     bc in (0, 1, 2, 3) || error("bc = $bc not in (0, 1, 2, 3)")
     y = Ref{Float64}(0)
     ier = Ref{Int32}(0)
     ccall((:splev_, libddierckx), Nothing,
-         (Ref{Float64}, Ref{Int32},
-          Ref{Float64}, Ref{Int32},
-          Ref{Float64}, Ref{Float64}, Ref{Int32},
-          Ref{Int32}, Ref{Int32}),
-         t, length(t), c, k, Float64(x), y, 1, bc, ier)
+        (Ref{Float64}, Ref{Int32},
+            Ref{Float64}, Ref{Int32},
+            Ref{Float64}, Ref{Float64}, Ref{Int32},
+            Ref{Int32}, Ref{Int32}),
+        t, length(t), c, k, Float64(x), y, 1, bc, ier)
 
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y[]
@@ -290,7 +285,7 @@ end
 
 evaluate(spline::Spline1D, x::AbstractVector) =
     _evaluate(spline.t, spline.c, spline.k,
-              convert(Vector{Float64}, x), spline.bc)
+        convert(Vector{Float64}, x), spline.bc)
 
 
 evaluate(spline::Spline1D, x::Real) =
@@ -298,36 +293,36 @@ evaluate(spline::Spline1D, x::Real) =
 
 
 function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                     x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64})
+    x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64})
     (1 <= nu <= k) || error("order of derivative must be positive and less than or equal to spline order")
     m = length(x)
     n = length(t)
     y = Vector{Float64}(undef, m)
     ier = Ref{Int32}(0)
     ccall((:splder_, libddierckx), Nothing,
-         (Ref{Float64}, Ref{Int32}, # t, n
-          Ref{Float64}, Ref{Int32}, # c, k
-          Ref{Int32}, # nu
-          Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
-          Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
-         t, n, c, k, nu, x, y, m, bc, wrk, ier)
+        (Ref{Float64}, Ref{Int32}, # t, n
+            Ref{Float64}, Ref{Int32}, # c, k
+            Ref{Int32}, # nu
+            Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
+            Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
+        t, n, c, k, nu, x, y, m, bc, wrk, ier)
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y
 end
 
 function _derivative(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                     x::Real, nu::Int, bc::Int, wrk::Vector{Float64})
+    x::Real, nu::Int, bc::Int, wrk::Vector{Float64})
     (1 <= nu <= k) || error("order of derivative must be positive and less than or equal to spline order")
     n = length(t)
     y = Ref{Float64}(0)
     ier = Ref{Int32}(0)
     ccall((:splder_, libddierckx), Nothing,
-         (Ref{Float64}, Ref{Int32}, # t, n
-          Ref{Float64}, Ref{Int32}, # c, k
-          Ref{Int32}, # nu
-          Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
-          Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
-         t, n, c, k, nu, Float64(x), y, 1, bc, wrk, ier)
+        (Ref{Float64}, Ref{Int32}, # t, n
+            Ref{Float64}, Ref{Int32}, # c, k
+            Ref{Int32}, # nu
+            Ref{Float64}, Ref{Float64}, Ref{Int32}, # x, y, m
+            Ref{Int32}, Ref{Float64}, Ref{Int32}), # e, wrk, ier
+        t, n, c, k, nu, Float64(x), y, 1, bc, wrk, ier)
     ier[] == 0 || error(_eval1d_messages[ier[]])
     return y[]
 end
@@ -336,29 +331,29 @@ end
 #       or should it be integrated with evaluate, above?
 #       (problem with that: derivative doesn't accept bc="nearest")
 # TODO: should `nu` be `d`?
-derivative(spline::Spline1D, x::AbstractVector, nu::Int=1) =
+derivative(spline::Spline1D, x::AbstractVector, nu::Int = 1) =
     _derivative(spline.t, spline.c, spline.k,
-                convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
+        convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
 
 
-derivative(spline::Spline1D, x::Real, nu::Int=1) =
+derivative(spline::Spline1D, x::Real, nu::Int = 1) =
     _derivative(spline.t, spline.c, spline.k, x, nu, spline.bc, spline.wrk)
 
 
 # TODO: deprecate this?
-derivative(spline::Spline1D, x; nu::Int=1) = derivative(spline, x, nu)
+derivative(spline::Spline1D, x; nu::Int = 1) = derivative(spline, x, nu)
 
 
 function _integrate(t::Vector{Float64}, c::Vector{Float64}, k::Int,
-                    a::Real, b::Real, wrk::Vector{Float64})
+    a::Real, b::Real, wrk::Vector{Float64})
     n = length(t)
     ccall((:splint_, libddierckx), Float64,
         (Ref{Float64}, Ref{Int32},
-         Ref{Float64}, Ref{Int32},
-         Ref{Float64}, Ref{Float64},
-         Ref{Float64}),
-         t, n, c, k,
-         Float64(a), Float64(b), wrk)
+            Ref{Float64}, Ref{Int32},
+            Ref{Float64}, Ref{Float64},
+            Ref{Float64}),
+        t, n, c, k,
+        Float64(a), Float64(b), wrk)
 end
 
 integrate(spline::Spline1D, a::Real, b::Real) =
@@ -366,7 +361,7 @@ integrate(spline::Spline1D, a::Real, b::Real) =
 
 # TODO roots for parametric splines
 # note: default maxn in scipy.interpolate is 3 * (length(spline.t) - 7)
-function roots(spline::Spline1D; maxn::Integer=8)
+function roots(spline::Spline1D; maxn::Integer = 8)
     if spline.k != 3
         error("root finding only supported for cubic splines (k=3)")
     end
@@ -375,12 +370,12 @@ function roots(spline::Spline1D; maxn::Integer=8)
     m = Vector{Int32}(undef, 1)
     ier = Vector{Int32}(undef, 1)
     ccall((:sproot_, libddierckx), Nothing,
-          (Ref{Float64}, Ref{Int32},  # t, n
-           Ref{Float64}, Ref{Float64},  # c, zeros
-           Ref{Int32}, Ref{Int32},  # mest, m
-           Ref{Int32}),  # ier
-          spline.t, n, spline.c, zeros,
-          maxn, m, ier)
+        (Ref{Float64}, Ref{Int32},  # t, n
+            Ref{Float64}, Ref{Float64},  # c, zeros
+            Ref{Int32}, Ref{Int32},  # mest, m
+            Ref{Int32}),  # ier
+        spline.t, n, spline.c, zeros,
+        maxn, m, ier)
 
     if ier[1] == 0
         return zeros[1:m[1]]
@@ -423,42 +418,42 @@ end
 
 
 function ParametricSpline(x::AbstractMatrix;
-                          w::AbstractVector=ones(size(x, 2)),
-                          k::Int=3, s::Real=0.0, bc::AbstractString="nearest",
-                          periodic::Bool=false)
+    w::AbstractVector = ones(size(x, 2)),
+    k::Int = 3, s::Real = 0.0, bc::AbstractString = "nearest",
+    periodic::Bool = false)
     return _ParametricSpline(nothing, x, nothing, w, k, s, bc, periodic)
 end
 
 # version with user-supplied u
 function ParametricSpline(u::AbstractVector, x::AbstractMatrix;
-                          ub::Real=u[1], ue::Real=u[end],
-                          w::AbstractVector=ones(size(x, 2)),
-                          k::Int=3, s::Real=0.0, bc::AbstractString="nearest",
-                          periodic::Bool=false)
+    ub::Real = u[1], ue::Real = u[end],
+    w::AbstractVector = ones(size(x, 2)),
+    k::Int = 3, s::Real = 0.0, bc::AbstractString = "nearest",
+    periodic::Bool = false)
     return _ParametricSpline(u, x, nothing, w, k, s, bc, periodic)
 end
 
 # version with user-supplied knots
 function ParametricSpline(x::AbstractMatrix, knots::AbstractVector;
-                          w::AbstractVector=ones(size(x, 2)),
-                          k::Int=3, bc::AbstractString="nearest",
-                          periodic::Bool=false)
+    w::AbstractVector = ones(size(x, 2)),
+    k::Int = 3, bc::AbstractString = "nearest",
+    periodic::Bool = false)
     return _ParametricSpline(nothing, x, knots, w, k, -1.0, bc, periodic)
 end
 
 # version with user-supplied u and knots
 function ParametricSpline(u::AbstractVector, x::AbstractMatrix,
-                          knots::AbstractVector;
-                          w::AbstractVector=ones(size(x, 2)),
-                          k::Int=3, bc::AbstractString="nearest",
-                          periodic::Bool=false)
+    knots::AbstractVector;
+    w::AbstractVector = ones(size(x, 2)),
+    k::Int = 3, bc::AbstractString = "nearest",
+    periodic::Bool = false)
     return _ParametricSpline(u, x, knots, w, k, -1.0, bc, periodic)
 end
 
-function _ParametricSpline(u::Union{AbstractVector, Nothing}, x::AbstractMatrix,
-                           knots::Union{AbstractVector, Nothing},
-                           w::AbstractVector, k::Int, s::Real,
-                           bc::AbstractString, periodic::Bool)
+function _ParametricSpline(u::Union{AbstractVector,Nothing}, x::AbstractMatrix,
+    knots::Union{AbstractVector,Nothing},
+    w::AbstractVector, k::Int, s::Real,
+    bc::AbstractString, periodic::Bool)
     idim, m = size(x)
     if periodic
         x[:, 1] == x[:, end] || error("for periodic splines x[:,1] and x[:,end] must match")
@@ -505,82 +500,82 @@ function _ParametricSpline(u::Union{AbstractVector, Nothing}, x::AbstractMatrix,
     xin = convert(Matrix{Float64}, x)
     win = convert(Vector{Float64}, w)
     n = Ref{Int32}(nest)
-    c = Vector{Float64}(undef, idim*nest)
+    c = Vector{Float64}(undef, idim * nest)
     fp = Ref{Float64}(0)
     ier = Ref{Int32}(0)
 
     local lwrk::Int
     if periodic
-        lwrk = m*(k + 1) + nest*(7 + idim + 5k)
+        lwrk = m * (k + 1) + nest * (7 + idim + 5k)
     else
-        lwrk = m*(k + 1) + nest*(6 + idim + 3k)
+        lwrk = m * (k + 1) + nest * (6 + idim + 3k)
     end
     wrk = Vector{Float64}(undef, lwrk)
     iwrk = Vector{Int32}(undef, nest)
 
     if !periodic
         ccall((:parcur_, libddierckx), Nothing,
-              (Ref{Int32}, Ref{Int32}, # iopt, ipar
-              Ref{Int32}, Ref{Int32}, # idim, m
-              Ref{Float64}, Ref{Int32}, # u, mx
-              Ref{Float64}, Ref{Float64}, # x, w
-              Ref{Float64}, Ref{Float64}, # ub, ue
-              Ref{Int32}, Ref{Float64}, # k, s
-              Ref{Int32}, Ref{Int32}, # nest, n
-              Ref{Float64}, Ref{Int32}, # t, nc
-              Ref{Float64}, Ref{Float64}, # c, fp
-              Ref{Float64}, Ref{Int32}, # wrk, lwrk
-              Ref{Int32}, Ref{Int32}), #iwrk, ier
-              iopt, ipar,
-              idim, m,
-              uin, length(x),
-              xin, win,
-              ub, ue,
-              k, s,
-              nest, n,
-              t, length(c),
-              c, fp,
-              wrk, lwrk,
-              iwrk, ier)
+            (Ref{Int32}, Ref{Int32}, # iopt, ipar
+                Ref{Int32}, Ref{Int32}, # idim, m
+                Ref{Float64}, Ref{Int32}, # u, mx
+                Ref{Float64}, Ref{Float64}, # x, w
+                Ref{Float64}, Ref{Float64}, # ub, ue
+                Ref{Int32}, Ref{Float64}, # k, s
+                Ref{Int32}, Ref{Int32}, # nest, n
+                Ref{Float64}, Ref{Int32}, # t, nc
+                Ref{Float64}, Ref{Float64}, # c, fp
+                Ref{Float64}, Ref{Int32}, # wrk, lwrk
+                Ref{Int32}, Ref{Int32}), #iwrk, ier
+            iopt, ipar,
+            idim, m,
+            uin, length(x),
+            xin, win,
+            ub, ue,
+            k, s,
+            nest, n,
+            t, length(c),
+            c, fp,
+            wrk, lwrk,
+            iwrk, ier)
     else
         ccall((:clocur_, libddierckx), Nothing,
-              (Ref{Int32}, Ref{Int32}, # iopt, ipar
-              Ref{Int32}, Ref{Int32}, # idim, m
-              Ref{Float64}, Ref{Int32}, # u, mx
-              Ref{Float64}, Ref{Float64}, # x, w
-              Ref{Int32}, Ref{Float64}, # k, s
-              Ref{Int32}, Ref{Int32}, # nest, n
-              Ref{Float64}, Ref{Int32}, # t, nc
-              Ref{Float64}, Ref{Float64}, # c, fp
-              Ref{Float64}, Ref{Int32}, # wrk, lwrk
-              Ref{Int32}, Ref{Int32}), #iwrk, ier
-              iopt, ipar,
-              idim, m,
-              uin, length(x),
-              xin, win,
-              k, s,
-              nest, n,
-              t, length(c),
-              c, fp,
-              wrk, lwrk,
-              iwrk, ier)
+            (Ref{Int32}, Ref{Int32}, # iopt, ipar
+                Ref{Int32}, Ref{Int32}, # idim, m
+                Ref{Float64}, Ref{Int32}, # u, mx
+                Ref{Float64}, Ref{Float64}, # x, w
+                Ref{Int32}, Ref{Float64}, # k, s
+                Ref{Int32}, Ref{Int32}, # nest, n
+                Ref{Float64}, Ref{Int32}, # t, nc
+                Ref{Float64}, Ref{Float64}, # c, fp
+                Ref{Float64}, Ref{Int32}, # wrk, lwrk
+                Ref{Int32}, Ref{Int32}), #iwrk, ier
+            iopt, ipar,
+            idim, m,
+            uin, length(x),
+            xin, win,
+            k, s,
+            nest, n,
+            t, length(c),
+            c, fp,
+            wrk, lwrk,
+            iwrk, ier)
     end
 
     ier[] <= 0 || error(_fit1d_messages[ier[]])
 
     resize!(t, n[])
-    c = [c[n[]*(j-1) + i] for j=1:idim, i=1:n[]-k-1]
+    c = [c[n[]*(j-1)+i] for j = 1:idim, i = 1:n[]-k-1]
 
     return ParametricSpline(t, c, k, _translate_bc(bc), fp[])
 end
 
 _evaluate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-          x::Vector{Float64}, bc::Int) =
-    mapslices(v -> _evaluate(t, v, k, x, bc), c, dims=[2])
+    x::Vector{Float64}, bc::Int) =
+    mapslices(v -> _evaluate(t, v, k, x, bc), c, dims = [2])
 
 _evaluate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-          x::Real, bc::Int) =
-    vec(mapslices(v -> _evaluate(t, v, k, x, bc), c, dims=[2]))
+    x::Real, bc::Int) =
+    vec(mapslices(v -> _evaluate(t, v, k, x, bc), c, dims = [2]))
 
 function evaluate(spline::ParametricSpline, x::AbstractVector)
     xin = convert(Vector{Float64}, x)
@@ -591,26 +586,26 @@ evaluate(spline::ParametricSpline, x::Real) =
     _evaluate(spline.t, spline.c, spline.k, x, spline.bc)
 
 _derivative(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-            x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64}) =
-    mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims=[2])
+    x::Vector{Float64}, nu::Int, bc::Int, wrk::Vector{Float64}) =
+    mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims = [2])
 
 _derivative(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-            x::Real, nu::Int, bc::Int, wrk::Vector{Float64}) =
-    vec(mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims=[2]))
+    x::Real, nu::Int, bc::Int, wrk::Vector{Float64}) =
+    vec(mapslices(v -> _derivative(t, v, k, x, nu, bc, wrk), c, dims = [2]))
 
-derivative(spline::ParametricSpline, x::AbstractVector, nu::Int=1) =
+derivative(spline::ParametricSpline, x::AbstractVector, nu::Int = 1) =
     _derivative(spline.t, spline.c, spline.k,
-                convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
+        convert(Vector{Float64}, x), nu, spline.bc, spline.wrk)
 
 # TODO: deprecate this
-derivative(spline::ParametricSpline, x; nu::Int=1) = derivative(spline, x, nu)
+derivative(spline::ParametricSpline, x; nu::Int = 1) = derivative(spline, x, nu)
 
-derivative(spline::ParametricSpline, x::Real, nu::Int=1) =
+derivative(spline::ParametricSpline, x::Real, nu::Int = 1) =
     _derivative(spline.t, spline.c, spline.k, x, nu, spline.bc, spline.wrk)
 
 _integrate(t::Vector{Float64}, c::Matrix{Float64}, k::Int,
-           a::Real, b::Real, wrk::Vector{Float64}) =
-    vec(mapslices(v -> _integrate(t, v, k, a, b, wrk), c, dims=[2]))
+    a::Real, b::Real, wrk::Vector{Float64}) =
+    vec(mapslices(v -> _integrate(t, v, k, a, b, wrk), c, dims = [2]))
 
 integrate(spline::ParametricSpline, a::Real, b::Real) =
     _integrate(spline.t, spline.c, spline.k, a, b, spline.wrk)
@@ -625,62 +620,45 @@ integrate(spline::ParametricSpline, a::Real, b::Real) =
 # swapped with regard to what the Fortran documentation says.
 
 const _fit2d_messages = Dict(
--3=>
+    -3 =>
+    """The coefficients of the spline returned have been computed as the
+    minimal norm least-squares solution of a (numerically) rank deficient
+    system (deficiency=%i). If deficiency is large, the results may be
+    inaccurate. Deficiency may strongly depend on the value of eps.""", 1 =>
+    """The required storage space exceeds the available storage space:
+    nxest or nyest too small, or s too small. Try increasing s.""",
+    # The weighted least-squares spline corresponds to the current set of knots.
 
-"""The coefficients of the spline returned have been computed as the
-minimal norm least-squares solution of a (numerically) rank deficient
-system (deficiency=%i). If deficiency is large, the results may be
-inaccurate. Deficiency may strongly depend on the value of eps.""",
-
-1=>
-
-"""The required storage space exceeds the available storage space:
-nxest or nyest too small, or s too small. Try increasing s.""",
-# The weighted least-squares spline corresponds to the current set of knots.
-
-2=>
-
-"""A theoretically impossible result was found during the iteration
-process for finding a smoothing spline with fp = s: s too small or
-badly chosen eps.  Weighted sum of squared residuals does not satisfy
-abs(fp-s)/s < tol.""",
-
-3=>
-
-"""the maximal number of iterations maxit (set to 20 by the program)
-allowed for finding a smoothing spline with fp=s has been reached: s
-too small.  Weighted sum of squared residuals does not satisfy
-abs(fp-s)/s < tol.""",
-
-4=>
-
-"""No more knots can be added because the number of b-spline
-coefficients (nx-kx-1)*(ny-ky-1) already exceeds the number of data
-points m: either s or m too small.  The weighted least-squares spline
-corresponds to the current set of knots.""",
-
-5=>
-
-"""No more knots can be added because the additional knot would
-(quasi) coincide with an old one: s too small or too large a weight to
-an inaccurate data point.  The weighted least-squares spline
-corresponds to the current set of knots.""",
-
-10=>
-
-"""Error on entry, no approximation returned. The following conditions
-must hold:
-xb<=x[i]<=xe, yb<=y[i]<=ye, w[i]>0, i=0..m-1
-If iopt==-1, then
-  xb<tx[kx+1]<tx[kx+2]<...<tx[nx-kx-2]<xe
-  yb<ty[ky+1]<ty[ky+2]<...<ty[ny-ky-2]<ye""")
+    2 =>
+    """A theoretically impossible result was found during the iteration
+    process for finding a smoothing spline with fp = s: s too small or
+    badly chosen eps.  Weighted sum of squared residuals does not satisfy
+    abs(fp-s)/s < tol.""", 3 =>
+    """the maximal number of iterations maxit (set to 20 by the program)
+    allowed for finding a smoothing spline with fp=s has been reached: s
+    too small.  Weighted sum of squared residuals does not satisfy
+    abs(fp-s)/s < tol.""", 4 =>
+    """No more knots can be added because the number of b-spline
+    coefficients (nx-kx-1)*(ny-ky-1) already exceeds the number of data
+    points m: either s or m too small.  The weighted least-squares spline
+    corresponds to the current set of knots.""", 5 =>
+    """No more knots can be added because the additional knot would
+    (quasi) coincide with an old one: s too small or too large a weight to
+    an inaccurate data point.  The weighted least-squares spline
+    corresponds to the current set of knots.""", 10 =>
+    """Error on entry, no approximation returned. The following conditions
+    must hold:
+    xb<=x[i]<=xe, yb<=y[i]<=ye, w[i]>0, i=0..m-1
+    If iopt==-1, then
+      xb<tx[kx+1]<tx[kx+2]<...<tx[nx-kx-2]<xe
+      yb<ty[ky+1]<ty[ky+2]<...<ty[ny-ky-2]<ye""")
 
 const _eval2d_message = (
-"""Invalid input data. Restrictions:
-length(x) != 0, length(y) != 0
-x[i-1] <= x[i] for i=2,...,length(x)
-y[j-1] <= y[j] for j=2,...,length(y)
-""")
+    """Invalid input data. Restrictions:
+    length(x) != 0, length(y) != 0
+    x[i-1] <= x[i] for i=2,...,length(x)
+    y[j-1] <= y[j] for j=2,...,length(y)
+    """)
 
 mutable struct Spline2D
     tx::Vector{Float64}
@@ -692,7 +670,7 @@ mutable struct Spline2D
 end
 
 get_knots(spl::Spline2D) = (spl.tx[spl.kx+1:end-spl.kx],
-                            spl.ty[spl.ky+1:end-spl.ky])
+    spl.ty[spl.ky+1:end-spl.ky])
 get_residual(spl::Spline2D) = spl.fp
 
 function ==(s1::Spline2D, s2::Spline2D)
@@ -707,17 +685,17 @@ function calc_surfit_lwrk1(m, kx, ky, nxest, nyest)
     v = nyest - ky - 1
     km = max(kx, ky) + 1
     ne = max(nxest, nyest)
-    bx = kx*v + ky + 1
-    by = ky*u + kx + 1
+    bx = kx * v + ky + 1
+    by = ky * u + kx + 1
     b1 = b2 = 0
-    if (bx<=by)
+    if (bx <= by)
         b1 = bx
         b2 = bx + v - ky
     else
         b1 = by
         b2 = by + u - kx
     end
-    return u*v*(2 + b1 + b2) + 2*(u+v+km*(m+ne)+ne-kx-ky) + b2 + 1
+    return u * v * (2 + b1 + b2) + 2 * (u + v + km * (m + ne) + ne - kx - ky) + b2 + 1
 end
 
 function calc_surfit_lwrk2(m, kx, ky, nxest, nyest)
@@ -731,16 +709,16 @@ end
 
 # Construct spline from unstructured data
 function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
-                  w::AbstractVector=ones(length(x)), kx::Int=3, ky::Int=3,
-                  s::Real=0.0)
+    w::AbstractVector = ones(length(x)), kx::Int = 3, ky::Int = 3,
+    s::Real = 0.0)
 
     # array sizes
     m = length(x)
     (length(y) == length(z) == m) || error("lengths of x, y, z must match")
     (length(w) == m) || error("length of w must match other inputs")
 
-    nxest = max(kx+1+ceil(Int,sqrt(m/2)), 2*(kx+1))
-    nyest = max(ky+1+ceil(Int,sqrt(m/2)), 2*(ky+1))
+    nxest = max(kx + 1 + ceil(Int, sqrt(m / 2)), 2 * (kx + 1))
+    nyest = max(ky + 1 + ceil(Int, sqrt(m / 2)), 2 * (ky + 1))
     nmax = max(nxest, nyest)
 
     eps = 1.0e-16
@@ -762,7 +740,7 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
     tx = Vector{Float64}(undef, nxest)
     ny = Ref{Int32}()
     ty = Vector{Float64}(undef, nyest)
-    c = Vector{Float64}(undef, (nxest-kx-1) * (nyest-ky-1))
+    c = Vector{Float64}(undef, (nxest - kx - 1) * (nyest - ky - 1))
     fp = Ref{Float64}()
     ier = Ref{Int32}()
 
@@ -770,29 +748,29 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
     # Note: in lwrk1 and lwrk2, x and y are swapped on purpose.
     lwrk1 = calc_surfit_lwrk1(m, ky, kx, nyest, nxest)
     lwrk2 = calc_surfit_lwrk2(m, ky, kx, nyest, nxest)
-    kwrk = m + (nxest - 2*kx - 1) * (nyest - 2*ky - 1)
+    kwrk = m + (nxest - 2 * kx - 1) * (nyest - 2 * ky - 1)
     wrk1 = Vector{Float64}(undef, lwrk1)
     wrk2 = Vector{Float64}(undef, lwrk2)
     iwrk = Vector{Int32}(undef, kwrk)
 
     ccall((:surfit_, libddierckx), Nothing,
-          (Ref{Int32}, Ref{Int32},  # iopt, m
-           Ref{Float64}, Ref{Float64},  # y, x
-           Ref{Float64}, Ref{Float64},  # z, w
-           Ref{Float64}, Ref{Float64},  # yb, ye
-           Ref{Float64}, Ref{Float64},  # xb, xe
-           Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
-           Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
-           Ref{Float64},  # eps
-           Ref{Int32}, Ref{Float64},  # ny, tx
-           Ref{Int32}, Ref{Float64},  # nx, tx
-           Ref{Float64}, Ref{Float64},  # c, fp
-           Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
-           Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
-           Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
-          0, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx,
-          Float64(s), nyest, nxest, nmax, eps, ny, ty, nx, tx,
-          c, fp, wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
+        (Ref{Int32}, Ref{Int32},  # iopt, m
+            Ref{Float64}, Ref{Float64},  # y, x
+            Ref{Float64}, Ref{Float64},  # z, w
+            Ref{Float64}, Ref{Float64},  # yb, ye
+            Ref{Float64}, Ref{Float64},  # xb, xe
+            Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
+            Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
+            Ref{Float64},  # eps
+            Ref{Int32}, Ref{Float64},  # ny, tx
+            Ref{Int32}, Ref{Float64},  # nx, tx
+            Ref{Float64}, Ref{Float64},  # c, fp
+            Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
+            Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
+            Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
+        0, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx,
+        Float64(s), nyest, nxest, nmax, eps, ny, ty, nx, tx,
+        c, fp, wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
 
     while ier[] > 10
         # lwrk2 is too small, i.e., there is not enough workspace
@@ -803,23 +781,23 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractVector;
         lwrk2 = ier[]
         resize!(wrk2, lwrk2)
         ccall((:surfit_, libddierckx), Nothing,
-              (Ref{Int32}, Ref{Int32},  # iopt, m
-               Ref{Float64}, Ref{Float64},  # y, x
-               Ref{Float64}, Ref{Float64},  # z, w
-               Ref{Float64}, Ref{Float64},  # yb, ye
-               Ref{Float64}, Ref{Float64},  # xb, xe
-               Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
-               Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
-               Ref{Float64},  # eps
-               Ref{Int32}, Ref{Float64},  # ny, tx
-               Ref{Int32}, Ref{Float64},  # nx, tx
-               Ref{Float64}, Ref{Float64},  # c, fp
-               Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
-               Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
-               Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
-              1, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx, s,
-              nyest, nxest, nmax, eps, ny, ty, nx, tx, c, fp,
-              wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
+            (Ref{Int32}, Ref{Int32},  # iopt, m
+                Ref{Float64}, Ref{Float64},  # y, x
+                Ref{Float64}, Ref{Float64},  # z, w
+                Ref{Float64}, Ref{Float64},  # yb, ye
+                Ref{Float64}, Ref{Float64},  # xb, xe
+                Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
+                Ref{Int32}, Ref{Int32}, Ref{Int32},  # nyest, nxest, nmax
+                Ref{Float64},  # eps
+                Ref{Int32}, Ref{Float64},  # ny, tx
+                Ref{Int32}, Ref{Float64},  # nx, tx
+                Ref{Float64}, Ref{Float64},  # c, fp
+                Ref{Float64}, Ref{Int32},  # wrk1, lwrk1
+                Ref{Float64}, Ref{Int32},  # wrk2, lwrk2
+                Ref{Int32}, Ref{Int32}, Ref{Int32}),   # iwrk, kwrk, ier
+            1, m, yin, xin, zin, win, yb, ye, xb, xe, ky, kx, s,
+            nyest, nxest, nmax, eps, ny, ty, nx, tx, c, fp,
+            wrk1, lwrk1, wrk2, lwrk2, iwrk, kwrk, ier)
     end
 
     if (ier[] == 0 || ier[] == -1 || ier[] == -2)
@@ -850,7 +828,7 @@ end
 
 # Construct spline from data on a grid.
 function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
-                  kx::Int=3, ky::Int=3, s::Real=0.0)
+    kx::Int = 3, ky::Int = 3, s::Real = 0.0)
     mx = length(x)
     my = length(y)
     @assert size(z, 1) == mx && size(z, 2) == my
@@ -863,8 +841,8 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
     xe = x[end]
     yb = y[1]
     ye = y[end]
-    nxest = mx+kx+1
-    nyest = my+ky+1
+    nxest = mx + kx + 1
+    nyest = my + ky + 1
 
     # ensure arrays are of correct type
     xin = convert(Vector{Float64}, x)
@@ -876,37 +854,37 @@ function Spline2D(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
     tx = Vector{Float64}(undef, nxest)
     ny = Ref{Int32}()
     ty = Vector{Float64}(undef, nyest)
-    c = Vector{Float64}(undef, (nxest-kx-1) * (nyest-ky-1))
+    c = Vector{Float64}(undef, (nxest - kx - 1) * (nyest - ky - 1))
     fp = Ref{Float64}()
     ier = Ref{Int32}()
 
     # Work arrays.
     # Note that in lwrk, x and y are swapped with respect to the Fortran
     # documentation. See "NOTE REGARDING ARGUMENT ORDER" above.
-    lwrk = (4 + nyest * (mx+2*ky+5) + nxest * (2*kx+5) +
-            my*(ky+1) + mx*(kx+1) + max(mx, nyest))
+    lwrk = (4 + nyest * (mx + 2 * ky + 5) + nxest * (2 * kx + 5) +
+            my * (ky + 1) + mx * (kx + 1) + max(mx, nyest))
     wrk = Vector{Float64}(undef, lwrk)
     kwrk = 3 + mx + my + nxest + nyest
     iwrk = Vector{Int32}(undef, kwrk)
 
     ccall((:regrid_, libddierckx), Nothing,
-          (Ref{Int32},  # iopt
-           Ref{Int32}, Ref{Float64},  # my, y
-           Ref{Int32}, Ref{Float64},  # mx, x
-           Ref{Float64},  # z
-           Ref{Float64}, Ref{Float64},  # yb, ye
-           Ref{Float64}, Ref{Float64},  # xb, xe
-           Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
-           Ref{Int32}, Ref{Int32},  # nyest, nxest
-           Ref{Int32}, Ref{Float64},  # ny, ty
-           Ref{Int32}, Ref{Float64},  # nx, tx
-           Ref{Float64}, Ref{Float64},  # c, fp
-           Ref{Float64}, Ref{Int32},  # wrk, lwrk
-           Ref{Int32}, Ref{Int32},  # iwrk, lwrk
-           Ref{Int32}),  # ier
-          0f0, my, yin, mx, xin, zin, yb, ye, xb, xe, ky, kx,
-          Float64(s), nyest, nxest, ny, ty, nx, tx, c, fp,
-          wrk, lwrk, iwrk, kwrk, ier)
+        (Ref{Int32},  # iopt
+            Ref{Int32}, Ref{Float64},  # my, y
+            Ref{Int32}, Ref{Float64},  # mx, x
+            Ref{Float64},  # z
+            Ref{Float64}, Ref{Float64},  # yb, ye
+            Ref{Float64}, Ref{Float64},  # xb, xe
+            Ref{Int32}, Ref{Int32}, Ref{Float64},  # ky, kx, s
+            Ref{Int32}, Ref{Int32},  # nyest, nxest
+            Ref{Int32}, Ref{Float64},  # ny, ty
+            Ref{Int32}, Ref{Float64},  # nx, tx
+            Ref{Float64}, Ref{Float64},  # c, fp
+            Ref{Float64}, Ref{Int32},  # wrk, lwrk
+            Ref{Int32}, Ref{Int32},  # iwrk, lwrk
+            Ref{Int32}),  # ier
+        0.0f0, my, yin, mx, xin, zin, yb, ye, xb, xe, ky, kx,
+        Float64(s), nyest, nxest, ny, ty, nx, tx, c, fp,
+        wrk, lwrk, iwrk, kwrk, ier)
 
     if !(ier[] == 0 || ier[] == -1 || ier[] == -2)
         error(_fit2d_messages[ier[]])
@@ -935,17 +913,17 @@ function evaluate(spline::Spline2D, x::AbstractVector, y::AbstractVector)
     z = Vector{Float64}(undef, m)
 
     ccall((:bispeu_, libddierckx), Nothing,
-          (Ref{Float64}, Ref{Int32},  # ty, ny
-           Ref{Float64}, Ref{Int32},  # tx, nx
-           Ref{Float64},  # c
-           Ref{Int32}, Ref{Int32},  # ky, kx
-           Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
-           Ref{Int32},  # m
-           Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
-          spline.ty, length(spline.ty),
-          spline.tx, length(spline.tx),
-          spline.c, spline.ky, spline.kx, yin, xin, z, m,
-          wrk, lwrk, ier)
+        (Ref{Float64}, Ref{Int32},  # ty, ny
+            Ref{Float64}, Ref{Int32},  # tx, nx
+            Ref{Float64},  # c
+            Ref{Int32}, Ref{Int32},  # ky, kx
+            Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
+            Ref{Int32},  # m
+            Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
+        spline.ty, length(spline.ty),
+        spline.tx, length(spline.tx),
+        spline.c, spline.ky, spline.kx, yin, xin, z, m,
+        wrk, lwrk, ier)
 
     ier[] == 0 || error(_eval2d_message)
 
@@ -958,17 +936,17 @@ function evaluate(spline::Spline2D, x::Real, y::Real)
     wrk = Vector{Float64}(undef, lwrk)
     z = Ref{Float64}()
     ccall((:bispeu_, libddierckx), Nothing,
-          (Ref{Float64}, Ref{Int32},  # ty, ny
-           Ref{Float64}, Ref{Int32},  # tx, nx
-           Ref{Float64},  # c
-           Ref{Int32}, Ref{Int32},  # ky, kx
-           Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
-           Ref{Int32},  # m
-           Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
-          spline.ty, length(spline.ty),
-          spline.tx, length(spline.tx),
-          spline.c, spline.ky, spline.kx, y, x, z, 1,
-          wrk, lwrk, ier)
+        (Ref{Float64}, Ref{Int32},  # ty, ny
+            Ref{Float64}, Ref{Int32},  # tx, nx
+            Ref{Float64},  # c
+            Ref{Int32}, Ref{Int32},  # ky, kx
+            Ref{Float64}, Ref{Float64}, Ref{Float64},  # y, x, z
+            Ref{Int32},  # m
+            Ref{Float64}, Ref{Int32}, Ref{Int32}),  # wrk, lwrk, ier
+        spline.ty, length(spline.ty),
+        spline.tx, length(spline.tx),
+        spline.c, spline.ky, spline.kx, y, x, z, 1,
+        wrk, lwrk, ier)
 
     ier[] == 0 || error(_eval2d_message)
     return z[]
@@ -982,7 +960,7 @@ function evalgrid(spline::Spline2D, x::AbstractVector, y::AbstractVector)
     xin = convert(Vector{Float64}, x)
     yin = convert(Vector{Float64}, y)
 
-    lwrk = mx*(spline.kx + 1) + my*(spline.ky + 1)
+    lwrk = mx * (spline.kx + 1) + my * (spline.ky + 1)
     wrk = Vector{Float64}(undef, lwrk)
     kwrk = mx + my
     iwrk = Vector{Int32}(undef, kwrk)
@@ -990,50 +968,122 @@ function evalgrid(spline::Spline2D, x::AbstractVector, y::AbstractVector)
     z = Matrix{Float64}(undef, mx, my)
 
     ccall((:bispev_, libddierckx), Nothing,
-          (Ref{Float64}, Ref{Int32},  # ty, ny
-           Ref{Float64}, Ref{Int32},  # tx, nx
-           Ref{Float64},  # c
-           Ref{Int32}, Ref{Int32},  # ky, kx
-           Ref{Float64}, Ref{Int32},  # y, my
-           Ref{Float64}, Ref{Int32},  # x, mx
-           Ref{Float64},  # z
-           Ref{Float64}, Ref{Int32},  # wrk, lwrk
-           Ref{Int32}, Ref{Int32},  # iwrk, kwrk
-           Ref{Int32}),  # ier
-          spline.ty, length(spline.ty),
-          spline.tx, length(spline.tx),
-          spline.c, spline.ky, spline.kx, yin, my, xin, mx, z,
-          wrk, lwrk, iwrk, kwrk, ier)
+        (Ref{Float64}, Ref{Int32},  # ty, ny
+            Ref{Float64}, Ref{Int32},  # tx, nx
+            Ref{Float64},  # c
+            Ref{Int32}, Ref{Int32},  # ky, kx
+            Ref{Float64}, Ref{Int32},  # y, my
+            Ref{Float64}, Ref{Int32},  # x, mx
+            Ref{Float64},  # z
+            Ref{Float64}, Ref{Int32},  # wrk, lwrk
+            Ref{Int32}, Ref{Int32},  # iwrk, kwrk
+            Ref{Int32}),  # ier
+        spline.ty, length(spline.ty),
+        spline.tx, length(spline.tx),
+        spline.c, spline.ky, spline.kx, yin, my, xin, mx, z,
+        wrk, lwrk, iwrk, kwrk, ier)
 
     ier[] == 0 || error(_eval2d_message)
 
     return z
 end
 
+function _derivative(tx::Vector{Float64}, ty::Vector{Float64}, c::Vector{Float64},
+    kx::Int, ky::Int, nux::Int, nuy::Int, x::Vector{Float64}, y::Vector{Float64},
+    wrk::Vector{Float64}, iwrk::Vector{Float64})
+    (0 <= nux < kx) || error("order of derivative must be positive and less than the spline order")
+    (0 <= nuy < ky) || error("order of derivative must be positive and less than the spline order")
+    mx = length(x)
+    my = length(y)
+    nx = length(tx)
+    ny = length(ty)
+    lwrk = length(wrk)
+    lwrkmin = mx * (kx + 1 - nux) + my * (ky + 1 - nuy) + (nx - kx - 1) * (ny - ky - 1)
+    lwrk >= lwrkmin || error("Length of wrk must be at least $lwrkmin")
+    kwrk = length(iwrk)
+    kwrk >= mx + my || error("length of iwrk must be greater than or equal to length(x) + length(y) = $(mx + my)")
+    z = Vector{Float64}(undef, mx * my)
+    ier = Ref{Int32}(0)
+    # the order of x and y are switched compared to the fortran implementation
+    # here x refers to rows and y to columns
+    ccall((:parder_, libddierckx), Nothing,
+        (Ref{Float64}, Ref{Int32}, # ty, ny
+            Ref{Float64}, Ref{Int32}, # tx, nx
+            Ref{Float64}, Ref{Int32}, Ref{Int32}, # c, ky, kx
+            Ref{Int32}, Ref{Int32}, # nuy, nux
+            Ref{Float64}, Ref{Int32}, Ref{Float64}, Ref{Int32}, Ref{Float64}, # y, my, x, mx, z
+            Ref{Float64}, Ref{Int32}, Ref{Float64}, Ref{Int32}, # wrk, lwrk, iwrk, kwrk
+            Ref{Int32}), # ier
+        ty, ny, tx, nx, c, ky, kx, nuy, nux, y, my, x, mx, z, wrk, lwrk, iwrk, kwrk, ier)
+    ier[] == 0 || error(_eval2d_message)
+    return reshape(z, mx, my)
+end
+
+function derivative(spline::Spline2D, x::AbstractVector, y::AbstractVector, nux::Int = 1, nuy::Int = 1)
+    mx = length(x)
+    my = length(y)
+    nx = length(spline.tx)
+    ny = length(spline.ty)
+
+    kx = spline.kx
+    ky = spline.ky
+
+    lwrkmin = mx * (kx + 1 - nux) + my * (ky + 1 - nuy) + (nx - kx - 1) * (ny - ky - 1)
+    lwrk = lwrkmin
+    wrk = Vector{Float64}(undef, lwrk)
+    kwrk = mx + my
+    iwrk = Vector{Float64}(undef, kwrk)
+
+    _derivative(spline.tx, spline.ty, spline.c,
+        spline.kx, spline.ky, nux, nuy,
+        convert(Vector{Float64}, x),
+        convert(Vector{Float64}, y),
+        wrk, iwrk)
+end
+
+function derivative(spline::Spline2D, x::Real, y::AbstractVector, nux::Int = 1, nuy::Int = 1)
+    z = derivative(spline, [Float64(x)], y, nux, nuy)
+    vec(z)
+end
+
+function derivative(spline::Spline2D, x::AbstractVector, y::Real, nux::Int = 1, nuy::Int = 1)
+    z = derivative(spline, x, [Float64(y)], nux, nuy)
+    vec(z)
+end
+function derivative(spline::Spline2D, x::Real, y::Real, nux::Int = 1, nuy::Int = 1)
+    z = derivative(spline, [Float64(x)], [Float64(y)], nux, nuy)
+    z[]
+end
+
+# TODO: deprecate this?
+function derivative(spline::Spline2D, x, y; nux::Int = 1, nuy::Int = 1)
+    derivative(spline, x, y, nux, nuy)
+end
+
 # 2D integration
 function integrate(spline::Spline2D, xb::Real, xe::Real, yb::Real, ye::Real)
-        nx = length(spline.tx)
-        ny = length(spline.ty)
+    nx = length(spline.tx)
+    ny = length(spline.ty)
 
-        kx = spline.kx
-        ky = spline.ky
+    kx = spline.kx
+    ky = spline.ky
 
-        wrk = Vector{Float64}(undef, nx + ny -kx - ky -2)
-        ccall((:dblint_, libddierckx), Float64,
-              (Ref{Float64}, Ref{Int32},  # tx, nx
-               Ref{Float64}, Ref{Int32},  # ty, ny
-               Ref{Float64}, Ref{Int32},  # c, kx
-               Ref{Int32}, #ky
-               Ref{Float64}, Ref{Float64},  # xb, xe
-               Ref{Float64}, Ref{Float64},  # yb, ye
-               Ref{Float64}),  # wrk
-              spline.tx, nx,
-              spline.ty, ny,
-              spline.c, spline.kx,
-              spline.ky,
-              xb, xe,
-              yb, ye,
-              wrk)
+    wrk = Vector{Float64}(undef, nx + ny - kx - ky - 2)
+    ccall((:dblint_, libddierckx), Float64,
+        (Ref{Float64}, Ref{Int32},  # tx, nx
+            Ref{Float64}, Ref{Int32},  # ty, ny
+            Ref{Float64}, Ref{Int32},  # c, kx
+            Ref{Int32}, #ky
+            Ref{Float64}, Ref{Float64},  # xb, xe
+            Ref{Float64}, Ref{Float64},  # yb, ye
+            Ref{Float64}),  # wrk
+        spline.tx, nx,
+        spline.ty, ny,
+        spline.c, spline.kx,
+        spline.ky,
+        xb, xe,
+        yb, ye,
+        wrk)
 end
 
 # call synonyms for evaluate():

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,92 +9,92 @@ using Random: seed!
 # -----------------------------------------------------------------------------
 # Spline1D
 
-x = [1., 2., 3.]
-y = [0., 2., 4.]
-spl = Spline1D(x, y; k=1, s=length(x))
+x = [1.0, 2.0, 3.0]
+y = [0.0, 2.0, 4.0]
+spl = Spline1D(x, y; k = 1, s = length(x))
 
 yi = evaluate(spl, [1.0, 1.5, 2.0])
 @test yi ≈ [0.0, 1.0, 2.0]
 @test evaluate(spl, 1.5) ≈ 1.0
-@test get_knots(spl) ≈ [1., 3.]
-@test get_coeffs(spl) ≈ [0., 4.]
-@test isapprox(get_residual(spl), 0.0, atol=1.e-30)
+@test get_knots(spl) ≈ [1.0, 3.0]
+@test get_coeffs(spl) ≈ [0.0, 4.0]
+@test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
 
 @test spl([1.0, 1.5, 2.0]) ≈ [0.0, 1.0, 2.0]
 @test spl(1.5) ≈ 1.0
 
 # test that a copy is returned by get_knots()
 knots = get_knots(spl)
-knots[1] = 1000.
-@test get_knots(spl) ≈ [1., 3.]
+knots[1] = 1000.0
+@test get_knots(spl) ≈ [1.0, 3.0]
 
 # test ported from scipy.interpolate testing this bug:
 # http://mail.scipy.org/pipermail/scipy-dev/2008-March/008507.html
-x = [-1., -0.65016502, -0.58856235, -0.26903553, -0.17370892,
-     -0.10011001, 0., 0.10011001, 0.17370892, 0.26903553, 0.58856235,
-     0.65016502, 1.]
-y = [1.,0.62928599, 0.5797223, 0.39965815, 0.36322694, 0.3508061,
+x = [-1.0, -0.65016502, -0.58856235, -0.26903553, -0.17370892,
+     -0.10011001, 0.0, 0.10011001, 0.17370892, 0.26903553, 0.58856235,
+     0.65016502, 1.0]
+y = [1.0, 0.62928599, 0.5797223, 0.39965815, 0.36322694, 0.3508061,
      0.35214793, 0.3508061, 0.36322694, 0.39965815, 0.5797223,
-     0.62928599, 1.]
+     0.62928599, 1.0]
 w = [1.00000000e+12, 6.88875973e+02, 4.89314737e+02, 4.26864807e+02,
      6.07746770e+02, 4.51341444e+02, 3.17480210e+02, 4.51341444e+02,
      6.07746770e+02, 4.26864807e+02, 4.89314737e+02, 6.88875973e+02,
      1.00000000e+12]
-spl = Spline1D(x, y; w=w, s=Float64(length(x)))
+spl = Spline1D(x, y; w = w, s = Float64(length(x)))
 desired = [0.35100374, 0.51715855, 0.87789547, 0.98719344]
 actual = evaluate(spl, [0.1, 0.5, 0.9, 0.99])
-@test isapprox(actual, desired, atol=5e-4)
+@test isapprox(actual, desired, atol = 5e-4)
 
 # test periodic
-x = [1., 2., 3., 4., 5.]
-y = [4., 1., 4., 1., 4.]
-spl = Spline1D(x, y, periodic=true)
+x = [1.0, 2.0, 3.0, 4.0, 5.0]
+y = [4.0, 1.0, 4.0, 1.0, 4.0]
+spl = Spline1D(x, y, periodic = true)
 
 @test derivative(spl, 1) ≈ derivative(spl, 5)
-@test derivative(spl, 1, nu=2) ≈ derivative(spl, 5, nu=2)
+@test derivative(spl, 1, nu = 2) ≈ derivative(spl, 5, nu = 2)
 
 # tests for out-of-range
 x = [0.0:4.0;]
-y = x.^3
+y = x .^ 3
 
-xp = range(-8.0, stop=13.0, length=100)
-xp_zeros = Float64[(0. <= xi <= 4.) ? xi : 0.0 for xi in xp]
-xp_clip = Float64[(0. <= xi <= 4.) ? xi : (xi < 0.0) ? 0.0 : 4. for xi in xp]
+xp = range(-8.0, stop = 13.0, length = 100)
+xp_zeros = Float64[(0.0 <= xi <= 4.0) ? xi : 0.0 for xi in xp]
+xp_clip = Float64[(0.0 <= xi <= 4.0) ? xi : (xi < 0.0) ? 0.0 : 4.0 for xi in xp]
 
 spl = Spline1D(x, y)
-t = get_knots(spl)[2: end-1]  # knots, excluding those at endpoints
+t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
 spl2 = Spline1D(x, y, t)
 
-@test evaluate(spl, xp) ≈ xp_clip.^3
-@test evaluate(spl2, xp) ≈ xp_clip.^3
+@test evaluate(spl, xp) ≈ xp_clip .^ 3
+@test evaluate(spl2, xp) ≈ xp_clip .^ 3
 
 # test other bc's
-spl = Spline1D(x, y; bc="extrapolate")
-@test evaluate(spl, xp) ≈ xp.^3
-spl = Spline1D(x, y; bc="zero")
-@test evaluate(spl, xp) ≈ xp_zeros.^3
-spl = Spline1D(x, y; bc="error")
+spl = Spline1D(x, y; bc = "extrapolate")
+@test evaluate(spl, xp) ≈ xp .^ 3
+spl = Spline1D(x, y; bc = "zero")
+@test evaluate(spl, xp) ≈ xp_zeros .^ 3
+spl = Spline1D(x, y; bc = "error")
 @test_throws ErrorException evaluate(spl, xp)
 
 # test unknown bc
-@test_throws ErrorException Spline1D(x, y; bc="unknown")
+@test_throws ErrorException Spline1D(x, y; bc = "unknown")
 
 # test derivative
-x = range(0, stop=1, length = 70)
-y = x.^3
+x = range(0, stop = 1, length = 70)
+y = x .^ 3
 spl = Spline1D(x, y)
 xt = [0.3, 0.4, 0.5]
-@test derivative(spl, xt) ≈ 3xt.^2
+@test derivative(spl, xt) ≈ 3xt .^ 2
 
 # test integral
-x = range(0, stop=10, length = 70)
-y = x.^2
+x = range(0, stop = 10, length = 70)
+y = x .^ 2
 spl = Spline1D(x, y)
-@test integrate(spl, 1.0, 5.0) ≈ 5.0^3/3 - 1/3
+@test integrate(spl, 1.0, 5.0) ≈ 5.0^3 / 3 - 1 / 3
 
 # test roots
-x = range(0, stop=10, length = 70)
-y = (x .- 4).^2 .- 1
+x = range(0, stop = 10, length = 70)
+y = (x .- 4) .^ 2 .- 1
 spl = Spline1D(x, y)
 @test roots(spl) ≈ [3, 5]
 
@@ -111,83 +111,83 @@ x = sort(rand(10))
 y = rand(10)
 sp1 = Spline1D(x, y)
 sp2 = Spline1D(x, y)
-sp3 = Spline1D(x.+1, y)
-sp4 = Spline1D(x, y.+1)
+sp3 = Spline1D(x .+ 1, y)
+sp4 = Spline1D(x, y .+ 1)
 @test sp1 == sp2
-@test allunique([sp1,sp3,sp4])
+@test allunique([sp1, sp3, sp4])
 
 
 # -----------------------------------------------------------------------------
 # ParametricSpline
 
-u = [1., 2., 3.]
-x = [1. 2. 3.; 0. 2. 4.]
-spl = ParametricSpline(u, x, k=1, s=size(x, 2))
+u = [1.0, 2.0, 3.0]
+x = [1.0 2.0 3.0; 0.0 2.0 4.0]
+spl = ParametricSpline(u, x, k = 1, s = size(x, 2))
 
 xi = evaluate(spl, [1.0, 1.5, 2.0])
 @test xi ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
 @test evaluate(spl, 1.5) ≈ [1.5, 1.0]
-@test get_knots(spl) ≈ [1., 3.]
+@test get_knots(spl) ≈ [1.0, 3.0]
 @test get_coeffs(spl) ≈ [1.0 3.0; 0.0 4.0]
-@test isapprox(get_residual(spl), 0.0, atol=1.e-30)
+@test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
 
 @test spl([1.0, 1.5, 2.0]) ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
 @test spl(1.5) ≈ [1.5, 1.0]
 
 # test that a copy is returned by get_knots()
 knots = get_knots(spl)
-knots[1] = 1000.
-@test get_knots(spl) ≈ [1., 3.]
+knots[1] = 1000.0
+@test get_knots(spl) ≈ [1.0, 3.0]
 
 # test periodic
-x = [23. 24. 25. 25. 24. 23.;
-     13. 12. 12. 13. 13. 13.]
-spl = ParametricSpline(x, periodic=true)
+x = [23.0 24.0 25.0 25.0 24.0 23.0
+     13.0 12.0 12.0 13.0 13.0 13.0]
+spl = ParametricSpline(x, periodic = true)
 @test evaluate(spl, 0) ≈ evaluate(spl, 1)
 @test derivative(spl, 0) ≈ derivative(spl, 1)
-@test derivative(spl, 0, nu=2) ≈ derivative(spl, 1, nu=2)
+@test derivative(spl, 0, nu = 2) ≈ derivative(spl, 1, nu = 2)
 
 # tests for out-of-range
 u = 0.0:4.0
-x = [u'.^2; u'.^3]
+x = [u' .^ 2; u' .^ 3]
 
-up = range(-8.0, stop=13.0, length = 100)
-up_zeros = Float64[(0. <= ui <= 4.) ? ui : 0.0 for ui in up]
-up_clip = Float64[(0. <= ui <= 4.) ? ui : (ui < 0.0) ? 0.0 : 4. for ui in up]
+up = range(-8.0, stop = 13.0, length = 100)
+up_zeros = Float64[(0.0 <= ui <= 4.0) ? ui : 0.0 for ui in up]
+up_clip = Float64[(0.0 <= ui <= 4.0) ? ui : (ui < 0.0) ? 0.0 : 4.0 for ui in up]
 
 spl = ParametricSpline(u, x)
-t = get_knots(spl)[2: end-1]  # knots, excluding those at endpoints
+t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
 spl2 = ParametricSpline(u, x, t)
 
-@test evaluate(spl, up) ≈ [up_clip'.^2; up_clip'.^3]
-@test evaluate(spl2, up) ≈ [up_clip'.^2; up_clip'.^3]
+@test evaluate(spl, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
+@test evaluate(spl2, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
 
 # test other bc's
-spl = ParametricSpline(u, x; bc="extrapolate")
-@test evaluate(spl, up) ≈ [up'.^2; up'.^3]
-spl = ParametricSpline(u, x; bc="zero")
-@test evaluate(spl, up) ≈ [up_zeros'.^2; up_zeros'.^3]
-spl = ParametricSpline(u, x; bc="error")
+spl = ParametricSpline(u, x; bc = "extrapolate")
+@test evaluate(spl, up) ≈ [up' .^ 2; up' .^ 3]
+spl = ParametricSpline(u, x; bc = "zero")
+@test evaluate(spl, up) ≈ [up_zeros' .^ 2; up_zeros' .^ 3]
+spl = ParametricSpline(u, x; bc = "error")
 @test_throws ErrorException evaluate(spl, up)
 
 # test unknown bc
-@test_throws ErrorException ParametricSpline(u, x; bc="unknown")
+@test_throws ErrorException ParametricSpline(u, x; bc = "unknown")
 
 # test derivative
-u = range(0, stop=1, length = 70)
-x = [u'.^2; u'.^3]
+u = range(0, stop = 1, length = 70)
+x = [u' .^ 2; u' .^ 3]
 spl = ParametricSpline(u, x)
 ut = [0.3, 0.4, 0.5]
-@test derivative(spl, 0.3) ≈ [2*0.3, 3*0.3^2]
-@test derivative(spl, ut) ≈ [2*ut'; 3*ut'.^2]
-@test derivative(spl, 0.3, nu=2) ≈ [2.0, 6*0.3]
-@test derivative(spl, ut, nu=2) ≈ [2*ones(3)'; 6*ut']
+@test derivative(spl, 0.3) ≈ [2 * 0.3, 3 * 0.3^2]
+@test derivative(spl, ut) ≈ [2 * ut'; 3 * ut' .^ 2]
+@test derivative(spl, 0.3, nu = 2) ≈ [2.0, 6 * 0.3]
+@test derivative(spl, ut, nu = 2) ≈ [2 * ones(3)'; 6 * ut']
 
 # test integral
-u = range(0, stop=10, length = 70)
-x = [u'.^2; u'.^3]
+u = range(0, stop = 10, length = 70)
+x = [u' .^ 2; u' .^ 3]
 spl = ParametricSpline(u, x)
-@test integrate(spl, 1.0, 5.0) ≈ [5.0^3/3 - 1/3, 5.0^4/4 - 1/4]
+@test integrate(spl, 1.0, 5.0) ≈ [5.0^3 / 3 - 1 / 3, 5.0^4 / 4 - 1 / 4]
 
 # test that show works.
 io = IOBuffer()
@@ -203,41 +203,41 @@ x = sort(rand(10))
 y = rand(3, 10)
 sp1 = ParametricSpline(x, y)
 sp2 = ParametricSpline(x, y)
-sp3 = ParametricSpline(x.+1, y)
-sp4 = ParametricSpline(x, y.+1)
+sp3 = ParametricSpline(x .+ 1, y)
+sp4 = ParametricSpline(x, y .+ 1)
 @test sp1 == sp2
-@test allunique([sp1,sp3,sp4])
+@test allunique([sp1, sp3, sp4])
 
 # test too many roots warning
 x = (0:100)
-y = (-1).^(0:100)
-sp = Spline1D(x,y)
-@test_logs (:warn,Regex("number of zeros exceeded")) roots(sp)
+y = (-1) .^ (0:100)
+sp = Spline1D(x, y)
+@test_logs (:warn, Regex("number of zeros exceeded")) roots(sp)
 
 
 # -----------------------------------------------------------------------------
 # Spline2D
 
 # test linear
-x = [1., 1., 1., 2., 2., 2., 3., 3., 3.]
-y = [1., 2., 3., 1., 2., 3., 1., 2., 3.]
-z = [0., 0., 0., 2., 2., 2., 4., 4., 4.]
-spl = Spline2D(x, y, z; kx=1, ky=1, s=length(x))
+x = [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0]
+y = [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
+z = [0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0]
+spl = Spline2D(x, y, z; kx = 1, ky = 1, s = length(x))
 tx, ty = get_knots(spl)
-@test tx ≈ [1., 3.]
-@test ty ≈ [1., 3.]
-@test isapprox(get_residual(spl), 0.0, atol=1e-16)
+@test tx ≈ [1.0, 3.0]
+@test ty ≈ [1.0, 3.0]
+@test isapprox(get_residual(spl), 0.0, atol = 1e-16)
 @test evaluate(spl, 2.0, 1.5) ≈ 2.0
-@test evalgrid(spl, [1.,1.5,2.], [1.,1.5]) ≈ [0. 0.; 1. 1.; 2. 2.]
+@test evalgrid(spl, [1.0, 1.5, 2.0], [1.0, 1.5]) ≈ [0.0 0.0; 1.0 1.0; 2.0 2.0]
 
 # test 1-d grid arrays
 @test evalgrid(spl, [2.0], [1.5])[1, 1] ≈ 2.0
 
 # In this setting, lwrk2 is too small in the default run.
-x = range(-2, stop=2, length = 80)
-y = range(-2, stop=2, length = 80)
+x = range(-2, stop = 2, length = 80)
+y = range(-2, stop = 2, length = 80)
 z = x .+ y
-spl = Spline2D(x, y, z; s=length(x))
+spl = Spline2D(x, y, z; s = length(x))
 @test evaluate(spl, 1.0, 1.0) ≈ 2.0
 
 # In this setting lwrk2 is too small multiple times!
@@ -246,29 +246,29 @@ seed!(0)
 x = rand(100)
 y = rand(100)
 z = sin.(x) .* sin.(y)
-@test_throws ErrorException Spline2D(x, y, z; kx=1, ky=1, s=0.0)
+@test_throws ErrorException Spline2D(x, y, z; kx = 1, ky = 1, s = 0.0)
 
 # test grid input creation
-x = [0.5, 2., 3., 4., 5.5, 8.]
-y = [0.5, 2., 3., 4.]
-z = [1. 2. 1. 2.;  # shape is (nx, ny)
-     1. 2. 1. 2.;
-     1. 2. 3. 2.;
-     1. 2. 2. 2.;
-     1. 2. 1. 2.;
-     1. 2. 3. 1.]
+x = [0.5, 2.0, 3.0, 4.0, 5.5, 8.0]
+y = [0.5, 2.0, 3.0, 4.0]
+z = [1.0 2.0 1.0 2.0  # shape is (nx, ny)
+     1.0 2.0 1.0 2.0
+     1.0 2.0 3.0 2.0
+     1.0 2.0 2.0 2.0
+     1.0 2.0 1.0 2.0
+     1.0 2.0 3.0 1.0]
 spl = Spline2D(x, y, z)
 
 # element-wise output
-xi = [1., 1.5, 2.3, 4.5, 3.3, 3.2, 3.]
-yi = [1., 2.3, 5.3, 0.5, 3.3, 1.2, 3.]
+xi = [1.0, 1.5, 2.3, 4.5, 3.3, 3.2, 3.0]
+yi = [1.0, 2.3, 5.3, 0.5, 3.3, 1.2, 3.0]
 ans = [2.94429906542,
-       1.25537598131,
-       2.00063588785,
-       1.0,
-       2.93952664,
-       1.06482509358,
-       3.0]
+     1.25537598131,
+     2.00063588785,
+     1.0,
+     2.93952664,
+     1.06482509358,
+     3.0]
 zi = evaluate(spl, xi, yi)
 @test zi ≈ ans
 
@@ -276,53 +276,86 @@ zi = spl(xi, yi)
 @test zi ≈ ans
 
 # grid output
-xi = [1., 1.5, 2.3, 4.5]
-yi = [1., 2.3, 5.3]
-ans = [2.94429906542  1.16946130841  1.99831775701;
-       2.80393858478  1.25537598131  1.99873831776;
-       1.67143209613  1.94853338542  2.00063588785;
-       1.89392523364  1.8126946729  2.01042056075]
+xi = [1.0, 1.5, 2.3, 4.5]
+yi = [1.0, 2.3, 5.3]
+ans = [2.94429906542 1.16946130841 1.99831775701
+     2.80393858478 1.25537598131 1.99873831776
+     1.67143209613 1.94853338542 2.00063588785
+     1.89392523364 1.8126946729 2.01042056075]
 zi = evalgrid(spl, xi, yi)
 @test zi ≈ ans
 
 
 # Test 2-d integration
-test2d_1(x, y) = 1 - x^2 -y^2
+test2d_1(x, y) = 1 - x^2 - y^2
 test2d_2(x, y) = cos(x) + sin(y)
-test2d_3(x, y) = x*exp(x-y)
-for (f, domain, exact) in [(test2d_1, (0.0, 1.0, 0.0, 1.0), 1.0/3.0),
-                           (test2d_2, (0.0, pi, 0.0, pi), 2.0*pi),
-                           (test2d_3, (0.0, 1.0, 0.0, 1.0), (ℯ-1.0)/ℯ)]
-    (x0, x1, y0, y1) = domain
+test2d_3(x, y) = x * exp(x - y)
+for (f, domain, exact) in [(test2d_1, (0.0, 1.0, 0.0, 1.0), 1.0 / 3.0),
+     (test2d_2, (0.0, pi, 0.0, pi), 2.0 * pi),
+     (test2d_3, (0.0, 1.0, 0.0, 1.0), (ℯ - 1.0) / ℯ)]
+     (x0, x1, y0, y1) = domain
 
-    # define grids for x and y dimensions:
-    npoints = 50
-    xgrid = range(x0, stop=x1, length = npoints)
-    ygrid = range(y0, stop=y1, length = npoints)
+     # define grids for x and y dimensions:
+     npoints = 50
+     xgrid = range(x0, stop = x1, length = npoints)
+     ygrid = range(y0, stop = y1, length = npoints)
 
-    fxygrid = zeros(npoints, npoints)
-    for (j, y) in enumerate(ygrid)
-        local j, y
-        for (i, x) in enumerate(xgrid)
-            local i, x
-            fxygrid[i,j] = f(x, y)
-        end
-    end
+     fxygrid = zeros(npoints, npoints)
+     for (j, y) in enumerate(ygrid)
+          local j, y
+          for (i, x) in enumerate(xgrid)
+               local i, x
+               fxygrid[i, j] = f(x, y)
+          end
+     end
 
-    spl1 = Spline2D(xgrid, ygrid, fxygrid)
-    @test isapprox(integrate(spl1, x0, x1, y0, y1), exact, atol=1e-6)
+     spl1 = Spline2D(xgrid, ygrid, fxygrid)
+     @test isapprox(integrate(spl1, x0, x1, y0, y1), exact, atol = 1e-6)
+end
+
+# test derivative
+@testset "2D spline derivative" begin
+     x = Vector{Float64}(1:4)
+     y = Vector{Float64}(1:5)
+     z = (x .^ 2) * (y .^ 3)'
+     s = Spline2D(x, y, z)
+     @testset "ddx" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 1, nuy = 0) ≈ 2xi * yi^3
+          end
+     end
+     @testset "d2dx2" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 2, nuy = 0) ≈ 2yi^3
+          end
+     end
+     @testset "ddy" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 0, nuy = 1) ≈ 3xi^2 * yi^2
+          end
+     end
+     @testset "d2dy2" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 0, nuy = 2) ≈ 6xi^2 * yi
+          end
+     end
+     @testset "ddx_ddy" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 1, nuy = 1) ≈ 6xi * yi^2
+          end
+     end
 end
 
 # test equality
 seed!(0)
 x = sort(rand(10))
 y = sort(rand(10))
-z = rand(10,10)
+z = rand(10, 10)
 sp1 = Spline2D(x, y, z)
 sp2 = Spline2D(x, y, z)
-sp3 = Spline2D(x.+1, y, z)
-sp4 = Spline2D(x, y.+1, z)
-sp5 = Spline2D(x, y, z.+1)
+sp3 = Spline2D(x .+ 1, y, z)
+sp4 = Spline2D(x, y .+ 1, z)
+sp5 = Spline2D(x, y, z .+ 1)
 @test sp1 == sp2
 @test allunique([sp1, sp3, sp4, sp5])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,382 +7,356 @@ using Random: seed!
 # generated with genanswers.py script.
 
 # -----------------------------------------------------------------------------
-@testset "Spline1D" begin
-     x = [1.0, 2.0, 3.0]
-     y = [0.0, 2.0, 4.0]
-     spl = Spline1D(x, y; k = 1, s = length(x))
+# Spline1D
 
-     yi = evaluate(spl, [1.0, 1.5, 2.0])
-     @test yi ≈ [0.0, 1.0, 2.0]
-     @test evaluate(spl, 1.5) ≈ 1.0
-     @test get_knots(spl) ≈ [1.0, 3.0]
-     @test get_coeffs(spl) ≈ [0.0, 4.0]
-     @test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
+x = [1., 2., 3.]
+y = [0., 2., 4.]
+spl = Spline1D(x, y; k=1, s=length(x))
 
-     @test spl([1.0, 1.5, 2.0]) ≈ [0.0, 1.0, 2.0]
-     @test spl(1.5) ≈ 1.0
+yi = evaluate(spl, [1.0, 1.5, 2.0])
+@test yi ≈ [0.0, 1.0, 2.0]
+@test evaluate(spl, 1.5) ≈ 1.0
+@test get_knots(spl) ≈ [1., 3.]
+@test get_coeffs(spl) ≈ [0., 4.]
+@test isapprox(get_residual(spl), 0.0, atol=1.e-30)
 
-     @testset "a copy is returned by get_knots()" begin
-          knots = get_knots(spl)
-          knots[1] = 1000.0
-          @test get_knots(spl) ≈ [1.0, 3.0]
-     end
+@test spl([1.0, 1.5, 2.0]) ≈ [0.0, 1.0, 2.0]
+@test spl(1.5) ≈ 1.0
 
-     # test ported from scipy.interpolate testing this bug:
-     # http://mail.scipy.org/pipermail/scipy-dev/2008-March/008507.html
-     x = [-1.0, -0.65016502, -0.58856235, -0.26903553, -0.17370892,
-          -0.10011001, 0.0, 0.10011001, 0.17370892, 0.26903553, 0.58856235,
-          0.65016502, 1.0]
-     y = [1.0, 0.62928599, 0.5797223, 0.39965815, 0.36322694, 0.3508061,
-          0.35214793, 0.3508061, 0.36322694, 0.39965815, 0.5797223,
-          0.62928599, 1.0]
-     w = [1.00000000e+12, 6.88875973e+02, 4.89314737e+02, 4.26864807e+02,
-          6.07746770e+02, 4.51341444e+02, 3.17480210e+02, 4.51341444e+02,
-          6.07746770e+02, 4.26864807e+02, 4.89314737e+02, 6.88875973e+02,
-          1.00000000e+12]
-     spl = Spline1D(x, y; w = w, s = Float64(length(x)))
-     desired = [0.35100374, 0.51715855, 0.87789547, 0.98719344]
-     actual = evaluate(spl, [0.1, 0.5, 0.9, 0.99])
-     @test isapprox(actual, desired, atol = 5e-4)
+# test that a copy is returned by get_knots()
+knots = get_knots(spl)
+knots[1] = 1000.
+@test get_knots(spl) ≈ [1., 3.]
 
-     @testset "periodic" begin
-          x = [1.0, 2.0, 3.0, 4.0, 5.0]
-          y = [4.0, 1.0, 4.0, 1.0, 4.0]
-          spl = Spline1D(x, y, periodic = true)
+# test ported from scipy.interpolate testing this bug:
+# http://mail.scipy.org/pipermail/scipy-dev/2008-March/008507.html
+x = [-1., -0.65016502, -0.58856235, -0.26903553, -0.17370892,
+     -0.10011001, 0., 0.10011001, 0.17370892, 0.26903553, 0.58856235,
+     0.65016502, 1.]
+y = [1.,0.62928599, 0.5797223, 0.39965815, 0.36322694, 0.3508061,
+     0.35214793, 0.3508061, 0.36322694, 0.39965815, 0.5797223,
+     0.62928599, 1.]
+w = [1.00000000e+12, 6.88875973e+02, 4.89314737e+02, 4.26864807e+02,
+     6.07746770e+02, 4.51341444e+02, 3.17480210e+02, 4.51341444e+02,
+     6.07746770e+02, 4.26864807e+02, 4.89314737e+02, 6.88875973e+02,
+     1.00000000e+12]
+spl = Spline1D(x, y; w=w, s=Float64(length(x)))
+desired = [0.35100374, 0.51715855, 0.87789547, 0.98719344]
+actual = evaluate(spl, [0.1, 0.5, 0.9, 0.99])
+@test isapprox(actual, desired, atol=5e-4)
 
-          @test derivative(spl, 1) ≈ derivative(spl, 5)
-          @test derivative(spl, 1, nu = 2) ≈ derivative(spl, 5, nu = 2)
-     end
+# test periodic
+x = [1., 2., 3., 4., 5.]
+y = [4., 1., 4., 1., 4.]
+spl = Spline1D(x, y, periodic=true)
 
-     @testset "out-of-range" begin
-          x = [0.0:4.0;]
-          y = x .^ 3
+@test derivative(spl, 1) ≈ derivative(spl, 5)
+@test derivative(spl, 1, nu=2) ≈ derivative(spl, 5, nu=2)
 
-          xp = range(-8.0, stop = 13.0, length = 100)
-          xp_zeros = Float64[(0.0 <= xi <= 4.0) ? xi : 0.0 for xi in xp]
-          xp_clip = Float64[(0.0 <= xi <= 4.0) ? xi : (xi < 0.0) ? 0.0 : 4.0 for xi in xp]
+# tests for out-of-range
+x = [0.0:4.0;]
+y = x.^3
 
-          spl = Spline1D(x, y)
-          t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
-          spl2 = Spline1D(x, y, t)
+xp = range(-8.0, stop=13.0, length=100)
+xp_zeros = Float64[(0. <= xi <= 4.) ? xi : 0.0 for xi in xp]
+xp_clip = Float64[(0. <= xi <= 4.) ? xi : (xi < 0.0) ? 0.0 : 4. for xi in xp]
 
-          @test evaluate(spl, xp) ≈ xp_clip .^ 3
-          @test evaluate(spl2, xp) ≈ xp_clip .^ 3
+spl = Spline1D(x, y)
+t = get_knots(spl)[2: end-1]  # knots, excluding those at endpoints
+spl2 = Spline1D(x, y, t)
 
-          @testset "other bc's" begin
-               spl = Spline1D(x, y; bc = "extrapolate")
-               @test evaluate(spl, xp) ≈ xp .^ 3
-               spl = Spline1D(x, y; bc = "zero")
-               @test evaluate(spl, xp) ≈ xp_zeros .^ 3
-               spl = Spline1D(x, y; bc = "error")
-               @test_throws ErrorException evaluate(spl, xp)
+@test evaluate(spl, xp) ≈ xp_clip.^3
+@test evaluate(spl2, xp) ≈ xp_clip.^3
 
-          end
+# test other bc's
+spl = Spline1D(x, y; bc="extrapolate")
+@test evaluate(spl, xp) ≈ xp.^3
+spl = Spline1D(x, y; bc="zero")
+@test evaluate(spl, xp) ≈ xp_zeros.^3
+spl = Spline1D(x, y; bc="error")
+@test_throws ErrorException evaluate(spl, xp)
 
-          @testset "unknown bc" begin
-               @test_throws ErrorException Spline1D(x, y; bc = "unknown")
-          end
-     end
+# test unknown bc
+@test_throws ErrorException Spline1D(x, y; bc="unknown")
 
-     @testset "derivative" begin
-          x = range(0, stop = 1, length = 70)
-          y = x .^ 3
-          spl = Spline1D(x, y)
-          xt = [0.3, 0.4, 0.5]
-          @test derivative(spl, xt) ≈ 3xt .^ 2
-     end
+# test derivative
+x = range(0, stop=1, length = 70)
+y = x.^3
+spl = Spline1D(x, y)
+xt = [0.3, 0.4, 0.5]
+@test derivative(spl, xt) ≈ 3xt.^2
 
-     @testset "integral" begin
-          x = range(0, stop = 10, length = 70)
-          y = x .^ 2
-          spl = Spline1D(x, y)
-          @test integrate(spl, 1.0, 5.0) ≈ 5.0^3 / 3 - 1 / 3
-     end
+# test integral
+x = range(0, stop=10, length = 70)
+y = x.^2
+spl = Spline1D(x, y)
+@test integrate(spl, 1.0, 5.0) ≈ 5.0^3/3 - 1/3
 
-     @testset "roots" begin
-          x = range(0, stop = 10, length = 70)
-          y = (x .- 4) .^ 2 .- 1
-          spl = Spline1D(x, y)
-          @test roots(spl) ≈ [3, 5]
-     end
+# test roots
+x = range(0, stop=10, length = 70)
+y = (x .- 4).^2 .- 1
+spl = Spline1D(x, y)
+@test roots(spl) ≈ [3, 5]
 
-     @testset "show" begin
-          io = IOBuffer()
-          show(io, spl)
-          seek(io, 0)
-          s = read(io, String)
-          @test s[1:9] == "Spline1D("
-     end
+# test that show works.
+io = IOBuffer()
+show(io, spl)
+seek(io, 0)
+s = read(io, String)
+@test s[1:9] == "Spline1D("
 
-     @testset "equality" begin
-          seed!(0)
-          x = sort(rand(10))
-          y = rand(10)
-          sp1 = Spline1D(x, y)
-          sp2 = Spline1D(x, y)
-          sp3 = Spline1D(x .+ 1, y)
-          sp4 = Spline1D(x, y .+ 1)
-          @test sp1 == sp2
-          @test allunique([sp1, sp3, sp4])
-     end
-end
+# test equality
+seed!(0)
+x = sort(rand(10))
+y = rand(10)
+sp1 = Spline1D(x, y)
+sp2 = Spline1D(x, y)
+sp3 = Spline1D(x.+1, y)
+sp4 = Spline1D(x, y.+1)
+@test sp1 == sp2
+@test allunique([sp1,sp3,sp4])
+
 
 # -----------------------------------------------------------------------------
-@testset "ParametricSpline" begin
-     u = [1.0, 2.0, 3.0]
-     x = [1.0 2.0 3.0; 0.0 2.0 4.0]
-     spl = ParametricSpline(u, x, k = 1, s = size(x, 2))
+# ParametricSpline
 
-     xi = evaluate(spl, [1.0, 1.5, 2.0])
-     @test xi ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
-     @test evaluate(spl, 1.5) ≈ [1.5, 1.0]
-     @test get_knots(spl) ≈ [1.0, 3.0]
-     @test get_coeffs(spl) ≈ [1.0 3.0; 0.0 4.0]
-     @test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
+u = [1., 2., 3.]
+x = [1. 2. 3.; 0. 2. 4.]
+spl = ParametricSpline(u, x, k=1, s=size(x, 2))
 
-     @test spl([1.0, 1.5, 2.0]) ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
-     @test spl(1.5) ≈ [1.5, 1.0]
+xi = evaluate(spl, [1.0, 1.5, 2.0])
+@test xi ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
+@test evaluate(spl, 1.5) ≈ [1.5, 1.0]
+@test get_knots(spl) ≈ [1., 3.]
+@test get_coeffs(spl) ≈ [1.0 3.0; 0.0 4.0]
+@test isapprox(get_residual(spl), 0.0, atol=1.e-30)
 
-     @testset "a copy is returned by get_knots()" begin
-          knots = get_knots(spl)
-          knots[1] = 1000.0
-          @test get_knots(spl) ≈ [1.0, 3.0]
-     end
+@test spl([1.0, 1.5, 2.0]) ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
+@test spl(1.5) ≈ [1.5, 1.0]
 
-     @testset "periodic" begin
-          x = [23.0 24.0 25.0 25.0 24.0 23.0
-               13.0 12.0 12.0 13.0 13.0 13.0]
-          spl = ParametricSpline(x, periodic = true)
-          @test evaluate(spl, 0) ≈ evaluate(spl, 1)
-          @test derivative(spl, 0) ≈ derivative(spl, 1)
-          @test derivative(spl, 0, nu = 2) ≈ derivative(spl, 1, nu = 2)
-     end
+# test that a copy is returned by get_knots()
+knots = get_knots(spl)
+knots[1] = 1000.
+@test get_knots(spl) ≈ [1., 3.]
 
-     @testset "out-of-range" begin
-          u = 0.0:4.0
-          x = [u' .^ 2; u' .^ 3]
+# test periodic
+x = [23. 24. 25. 25. 24. 23.;
+     13. 12. 12. 13. 13. 13.]
+spl = ParametricSpline(x, periodic=true)
+@test evaluate(spl, 0) ≈ evaluate(spl, 1)
+@test derivative(spl, 0) ≈ derivative(spl, 1)
+@test derivative(spl, 0, nu=2) ≈ derivative(spl, 1, nu=2)
 
-          up = range(-8.0, stop = 13.0, length = 100)
-          up_zeros = Float64[(0.0 <= ui <= 4.0) ? ui : 0.0 for ui in up]
-          up_clip = Float64[(0.0 <= ui <= 4.0) ? ui : (ui < 0.0) ? 0.0 : 4.0 for ui in up]
+# tests for out-of-range
+u = 0.0:4.0
+x = [u'.^2; u'.^3]
 
-          spl = ParametricSpline(u, x)
-          t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
-          spl2 = ParametricSpline(u, x, t)
+up = range(-8.0, stop=13.0, length = 100)
+up_zeros = Float64[(0. <= ui <= 4.) ? ui : 0.0 for ui in up]
+up_clip = Float64[(0. <= ui <= 4.) ? ui : (ui < 0.0) ? 0.0 : 4. for ui in up]
 
-          @test evaluate(spl, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
-          @test evaluate(spl2, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
+spl = ParametricSpline(u, x)
+t = get_knots(spl)[2: end-1]  # knots, excluding those at endpoints
+spl2 = ParametricSpline(u, x, t)
 
-          @testset "other bc's" begin
-               spl = ParametricSpline(u, x; bc = "extrapolate")
-               @test evaluate(spl, up) ≈ [up' .^ 2; up' .^ 3]
-               spl = ParametricSpline(u, x; bc = "zero")
-               @test evaluate(spl, up) ≈ [up_zeros' .^ 2; up_zeros' .^ 3]
-               spl = ParametricSpline(u, x; bc = "error")
-               @test_throws ErrorException evaluate(spl, up)
+@test evaluate(spl, up) ≈ [up_clip'.^2; up_clip'.^3]
+@test evaluate(spl2, up) ≈ [up_clip'.^2; up_clip'.^3]
 
-          end
+# test other bc's
+spl = ParametricSpline(u, x; bc="extrapolate")
+@test evaluate(spl, up) ≈ [up'.^2; up'.^3]
+spl = ParametricSpline(u, x; bc="zero")
+@test evaluate(spl, up) ≈ [up_zeros'.^2; up_zeros'.^3]
+spl = ParametricSpline(u, x; bc="error")
+@test_throws ErrorException evaluate(spl, up)
 
-          @testset "unknown bc" begin
-               @test_throws ErrorException ParametricSpline(u, x; bc = "unknown")
-          end
-     end
+# test unknown bc
+@test_throws ErrorException ParametricSpline(u, x; bc="unknown")
 
-     @testset "derivative" begin
-          u = range(0, stop = 1, length = 70)
-          x = [u' .^ 2; u' .^ 3]
-          spl = ParametricSpline(u, x)
-          ut = [0.3, 0.4, 0.5]
-          @test derivative(spl, 0.3) ≈ [2 * 0.3, 3 * 0.3^2]
-          @test derivative(spl, ut) ≈ [2 * ut'; 3 * ut' .^ 2]
-          @test derivative(spl, 0.3, nu = 2) ≈ [2.0, 6 * 0.3]
-          @test derivative(spl, ut, nu = 2) ≈ [2 * ones(3)'; 6 * ut']
-     end
+# test derivative
+u = range(0, stop=1, length = 70)
+x = [u'.^2; u'.^3]
+spl = ParametricSpline(u, x)
+ut = [0.3, 0.4, 0.5]
+@test derivative(spl, 0.3) ≈ [2*0.3, 3*0.3^2]
+@test derivative(spl, ut) ≈ [2*ut'; 3*ut'.^2]
+@test derivative(spl, 0.3, nu=2) ≈ [2.0, 6*0.3]
+@test derivative(spl, ut, nu=2) ≈ [2*ones(3)'; 6*ut']
 
-     @testset "integral" begin
-          u = range(0, stop = 10, length = 70)
-          x = [u' .^ 2; u' .^ 3]
-          spl = ParametricSpline(u, x)
-          @test integrate(spl, 1.0, 5.0) ≈ [5.0^3 / 3 - 1 / 3, 5.0^4 / 4 - 1 / 4]
-     end
+# test integral
+u = range(0, stop=10, length = 70)
+x = [u'.^2; u'.^3]
+spl = ParametricSpline(u, x)
+@test integrate(spl, 1.0, 5.0) ≈ [5.0^3/3 - 1/3, 5.0^4/4 - 1/4]
 
-     @testset "show" begin
-          io = IOBuffer()
-          show(io, spl)
-          seek(io, 0)
-          s = read(io, String)
-          @test s[1:17] == "ParametricSpline("
-     end
+# test that show works.
+io = IOBuffer()
+show(io, spl)
+seek(io, 0)
+s = read(io, String)
+@test s[1:17] == "ParametricSpline("
 
-     @testset "equality" begin
-          seed!(0)
-          x = sort(rand(10))
-          y = rand(3, 10)
-          sp1 = ParametricSpline(x, y)
-          sp2 = ParametricSpline(x, y)
-          sp3 = ParametricSpline(x .+ 1, y)
-          sp4 = ParametricSpline(x, y .+ 1)
-          @test sp1 == sp2
-          @test allunique([sp1, sp3, sp4])
-     end
 
-     @testset "too many roots warning" begin
-          x = (0:100)
-          y = (-1) .^ (0:100)
-          sp = Spline1D(x, y)
-          @test_logs (:warn, Regex("number of zeros exceeded")) roots(sp)
-     end
-end
+# test equality
+seed!(0)
+x = sort(rand(10))
+y = rand(3, 10)
+sp1 = ParametricSpline(x, y)
+sp2 = ParametricSpline(x, y)
+sp3 = ParametricSpline(x.+1, y)
+sp4 = ParametricSpline(x, y.+1)
+@test sp1 == sp2
+@test allunique([sp1,sp3,sp4])
+
+# test too many roots warning
+x = (0:100)
+y = (-1).^(0:100)
+sp = Spline1D(x,y)
+@test_logs (:warn,Regex("number of zeros exceeded")) roots(sp)
+
 
 # -----------------------------------------------------------------------------
-@testset "Spline2D" begin
-     @testset "linear" begin
-          x = [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0]
-          y = [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
-          z = [0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0]
-          spl = Spline2D(x, y, z; kx = 1, ky = 1, s = length(x))
-          tx, ty = get_knots(spl)
-          @test tx ≈ [1.0, 3.0]
-          @test ty ≈ [1.0, 3.0]
-          @test isapprox(get_residual(spl), 0.0, atol = 1e-16)
-          @test evaluate(spl, 2.0, 1.5) ≈ 2.0
-          @test evalgrid(spl, [1.0, 1.5, 2.0], [1.0, 1.5]) ≈ [0.0 0.0; 1.0 1.0; 2.0 2.0]
+# Spline2D
 
-          @testset "1-d grid arrays" begin
-               @test evalgrid(spl, [2.0], [1.5])[1, 1] ≈ 2.0
+# test linear
+x = [1., 1., 1., 2., 2., 2., 3., 3., 3.]
+y = [1., 2., 3., 1., 2., 3., 1., 2., 3.]
+z = [0., 0., 0., 2., 2., 2., 4., 4., 4.]
+spl = Spline2D(x, y, z; kx=1, ky=1, s=length(x))
+tx, ty = get_knots(spl)
+@test tx ≈ [1., 3.]
+@test ty ≈ [1., 3.]
+@test isapprox(get_residual(spl), 0.0, atol=1e-16)
+@test evaluate(spl, 2.0, 1.5) ≈ 2.0
+@test evalgrid(spl, [1.,1.5,2.], [1.,1.5]) ≈ [0. 0.; 1. 1.; 2. 2.]
+
+# test 1-d grid arrays
+@test evalgrid(spl, [2.0], [1.5])[1, 1] ≈ 2.0
+
+# In this setting, lwrk2 is too small in the default run.
+x = range(-2, stop=2, length = 80)
+y = range(-2, stop=2, length = 80)
+z = x .+ y
+spl = Spline2D(x, y, z; s=length(x))
+@test evaluate(spl, 1.0, 1.0) ≈ 2.0
+
+# In this setting lwrk2 is too small multiple times!
+# Eventually an error about s being too small is thrown.
+seed!(0)
+x = rand(100)
+y = rand(100)
+z = sin.(x) .* sin.(y)
+@test_throws ErrorException Spline2D(x, y, z; kx=1, ky=1, s=0.0)
+
+# test grid input creation
+x = [0.5, 2., 3., 4., 5.5, 8.]
+y = [0.5, 2., 3., 4.]
+z = [1. 2. 1. 2.;  # shape is (nx, ny)
+     1. 2. 1. 2.;
+     1. 2. 3. 2.;
+     1. 2. 2. 2.;
+     1. 2. 1. 2.;
+     1. 2. 3. 1.]
+spl = Spline2D(x, y, z)
+
+# element-wise output
+xi = [1., 1.5, 2.3, 4.5, 3.3, 3.2, 3.]
+yi = [1., 2.3, 5.3, 0.5, 3.3, 1.2, 3.]
+ans = [2.94429906542,
+       1.25537598131,
+       2.00063588785,
+       1.0,
+       2.93952664,
+       1.06482509358,
+       3.0]
+zi = evaluate(spl, xi, yi)
+@test zi ≈ ans
+
+zi = spl(xi, yi)
+@test zi ≈ ans
+
+# grid output
+xi = [1., 1.5, 2.3, 4.5]
+yi = [1., 2.3, 5.3]
+ans = [2.94429906542  1.16946130841  1.99831775701;
+       2.80393858478  1.25537598131  1.99873831776;
+       1.67143209613  1.94853338542  2.00063588785;
+       1.89392523364  1.8126946729  2.01042056075]
+zi = evalgrid(spl, xi, yi)
+@test zi ≈ ans
+
+
+# Test 2-d integration
+test2d_1(x, y) = 1 - x^2 -y^2
+test2d_2(x, y) = cos(x) + sin(y)
+test2d_3(x, y) = x*exp(x-y)
+for (f, domain, exact) in [(test2d_1, (0.0, 1.0, 0.0, 1.0), 1.0/3.0),
+                           (test2d_2, (0.0, pi, 0.0, pi), 2.0*pi),
+                           (test2d_3, (0.0, 1.0, 0.0, 1.0), (ℯ-1.0)/ℯ)]
+    (x0, x1, y0, y1) = domain
+
+    # define grids for x and y dimensions:
+    npoints = 50
+    xgrid = range(x0, stop=x1, length = npoints)
+    ygrid = range(y0, stop=y1, length = npoints)
+
+    fxygrid = zeros(npoints, npoints)
+    for (j, y) in enumerate(ygrid)
+        local j, y
+        for (i, x) in enumerate(xgrid)
+            local i, x
+            fxygrid[i,j] = f(x, y)
+        end
+    end
+
+    spl1 = Spline2D(xgrid, ygrid, fxygrid)
+    @test isapprox(integrate(spl1, x0, x1, y0, y1), exact, atol=1e-6)
+end
+
+# test derivative
+@testset "2D spline derivative" begin
+     x = Vector{Float64}(1:4)
+     y = Vector{Float64}(1:5)
+     z = (x .^ 2) * (y .^ 3)'
+     s = Spline2D(x, y, z)
+     @testset "ddx" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 1, nuy = 0) ≈ 2xi * yi^3
           end
      end
-
-     @testset "too small lwrk2" begin
-          # In this setting, lwrk2 is too small in the default run.
-          x = range(-2, stop = 2, length = 80)
-          y = range(-2, stop = 2, length = 80)
-          z = x .+ y
-          spl = Spline2D(x, y, z; s = length(x))
-          @test evaluate(spl, 1.0, 1.0) ≈ 2.0
-
-          # In this setting lwrk2 is too small multiple times!
-          # Eventually an error about s being too small is thrown.
-          seed!(0)
-          x = rand(100)
-          y = rand(100)
-          z = sin.(x) .* sin.(y)
-          @test_throws ErrorException Spline2D(x, y, z; kx = 1, ky = 1, s = 0.0)
-     end
-
-     @testset "grid input creation" begin
-          x = [0.5, 2.0, 3.0, 4.0, 5.5, 8.0]
-          y = [0.5, 2.0, 3.0, 4.0]
-          z = [1.0 2.0 1.0 2.0  # shape is (nx, ny)
-               1.0 2.0 1.0 2.0
-               1.0 2.0 3.0 2.0
-               1.0 2.0 2.0 2.0
-               1.0 2.0 1.0 2.0
-               1.0 2.0 3.0 1.0]
-          spl = Spline2D(x, y, z)
-          # element-wise output
-          @testset "element wise output" begin
-               xi = [1.0, 1.5, 2.3, 4.5, 3.3, 3.2, 3.0]
-               yi = [1.0, 2.3, 5.3, 0.5, 3.3, 1.2, 3.0]
-               ans = [2.94429906542,
-                    1.25537598131,
-                    2.00063588785,
-                    1.0,
-                    2.93952664,
-                    1.06482509358,
-                    3.0]
-               zi = evaluate(spl, xi, yi)
-               @test zi ≈ ans
-
-               zi = spl(xi, yi)
-               @test zi ≈ ans
-          end
-          @testset "grid output" begin
-               xi = [1.0, 1.5, 2.3, 4.5]
-               yi = [1.0, 2.3, 5.3]
-               ans = [2.94429906542 1.16946130841 1.99831775701
-                    2.80393858478 1.25537598131 1.99873831776
-                    1.67143209613 1.94853338542 2.00063588785
-                    1.89392523364 1.8126946729 2.01042056075]
-               zi = evalgrid(spl, xi, yi)
-               @test zi ≈ ans
+     @testset "d2dx2" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 2, nuy = 0) ≈ 2yi^3
           end
      end
-
-     # Test 2-d integration
-     @testset "integration" begin
-          test2d_1(x, y) = 1 - x^2 - y^2
-          test2d_2(x, y) = cos(x) + sin(y)
-          test2d_3(x, y) = x * exp(x - y)
-          for (f, domain, exact) in [(test2d_1, (0.0, 1.0, 0.0, 1.0), 1.0 / 3.0),
-               (test2d_2, (0.0, pi, 0.0, pi), 2.0 * pi),
-               (test2d_3, (0.0, 1.0, 0.0, 1.0), (ℯ - 1.0) / ℯ)]
-               (x0, x1, y0, y1) = domain
-
-               # define grids for x and y dimensions:
-               npoints = 50
-               xgrid = range(x0, stop = x1, length = npoints)
-               ygrid = range(y0, stop = y1, length = npoints)
-
-               fxygrid = zeros(npoints, npoints)
-               for (j, y) in enumerate(ygrid)
-                    local j, y
-                    for (i, x) in enumerate(xgrid)
-                         local i, x
-                         fxygrid[i, j] = f(x, y)
-                    end
-               end
-
-               spl1 = Spline2D(xgrid, ygrid, fxygrid)
-               @test isapprox(integrate(spl1, x0, x1, y0, y1), exact, atol = 1e-6)
+     @testset "ddy" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 0, nuy = 1) ≈ 3xi^2 * yi^2
           end
      end
-
-     # test derivative
-     @testset "derivative" begin
-          x = Vector{Float64}(1:4)
-          y = Vector{Float64}(1:5)
-          z = (x .^ 2) * (y .^ 3)'
-          s = Spline2D(x, y, z)
-          @testset "ddx" begin
-               for xi in x, yi in y
-                    @test derivative(s, xi, yi, nux = 1, nuy = 0) ≈ 2xi * yi^3
-               end
-          end
-          @testset "d2dx2" begin
-               for xi in x, yi in y
-                    @test derivative(s, xi, yi, nux = 2, nuy = 0) ≈ 2yi^3
-               end
-          end
-          @testset "ddy" begin
-               for xi in x, yi in y
-                    @test derivative(s, xi, yi, nux = 0, nuy = 1) ≈ 3xi^2 * yi^2
-               end
-          end
-          @testset "d2dy2" begin
-               for xi in x, yi in y
-                    @test derivative(s, xi, yi, nux = 0, nuy = 2) ≈ 6xi^2 * yi
-               end
-          end
-          @testset "ddx_ddy" begin
-               for xi in x, yi in y
-                    @test derivative(s, xi, yi, nux = 1, nuy = 1) ≈ 6xi * yi^2
-               end
+     @testset "d2dy2" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 0, nuy = 2) ≈ 6xi^2 * yi
           end
      end
-
-     # test equality
-     @testset "equality" begin
-          seed!(0)
-          x = sort(rand(10))
-          y = sort(rand(10))
-          z = rand(10, 10)
-          sp1 = Spline2D(x, y, z)
-          sp2 = Spline2D(x, y, z)
-          sp3 = Spline2D(x .+ 1, y, z)
-          sp4 = Spline2D(x, y .+ 1, z)
-          sp5 = Spline2D(x, y, z .+ 1)
-          @test sp1 == sp2
-          @test allunique([sp1, sp3, sp4, sp5])
+     @testset "ddx_ddy" begin
+          for xi in x, yi in y
+               @test derivative(s, xi, yi, nux = 1, nuy = 1) ≈ 6xi * yi^2
+          end
      end
 end
+
+# test equality
+seed!(0)
+x = sort(rand(10))
+y = sort(rand(10))
+z = rand(10,10)
+sp1 = Spline2D(x, y, z)
+sp2 = Spline2D(x, y, z)
+sp3 = Spline2D(x.+1, y, z)
+sp4 = Spline2D(x, y.+1, z)
+sp5 = Spline2D(x, y, z.+1)
+@test sp1 == sp2
+@test allunique([sp1, sp3, sp4, sp5])
+
+println("All tests passed.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,356 +7,382 @@ using Random: seed!
 # generated with genanswers.py script.
 
 # -----------------------------------------------------------------------------
-# Spline1D
+@testset "Spline1D" begin
+     x = [1.0, 2.0, 3.0]
+     y = [0.0, 2.0, 4.0]
+     spl = Spline1D(x, y; k = 1, s = length(x))
 
-x = [1.0, 2.0, 3.0]
-y = [0.0, 2.0, 4.0]
-spl = Spline1D(x, y; k = 1, s = length(x))
+     yi = evaluate(spl, [1.0, 1.5, 2.0])
+     @test yi ≈ [0.0, 1.0, 2.0]
+     @test evaluate(spl, 1.5) ≈ 1.0
+     @test get_knots(spl) ≈ [1.0, 3.0]
+     @test get_coeffs(spl) ≈ [0.0, 4.0]
+     @test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
 
-yi = evaluate(spl, [1.0, 1.5, 2.0])
-@test yi ≈ [0.0, 1.0, 2.0]
-@test evaluate(spl, 1.5) ≈ 1.0
-@test get_knots(spl) ≈ [1.0, 3.0]
-@test get_coeffs(spl) ≈ [0.0, 4.0]
-@test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
+     @test spl([1.0, 1.5, 2.0]) ≈ [0.0, 1.0, 2.0]
+     @test spl(1.5) ≈ 1.0
 
-@test spl([1.0, 1.5, 2.0]) ≈ [0.0, 1.0, 2.0]
-@test spl(1.5) ≈ 1.0
+     @testset "a copy is returned by get_knots()" begin
+          knots = get_knots(spl)
+          knots[1] = 1000.0
+          @test get_knots(spl) ≈ [1.0, 3.0]
+     end
 
-# test that a copy is returned by get_knots()
-knots = get_knots(spl)
-knots[1] = 1000.0
-@test get_knots(spl) ≈ [1.0, 3.0]
+     # test ported from scipy.interpolate testing this bug:
+     # http://mail.scipy.org/pipermail/scipy-dev/2008-March/008507.html
+     x = [-1.0, -0.65016502, -0.58856235, -0.26903553, -0.17370892,
+          -0.10011001, 0.0, 0.10011001, 0.17370892, 0.26903553, 0.58856235,
+          0.65016502, 1.0]
+     y = [1.0, 0.62928599, 0.5797223, 0.39965815, 0.36322694, 0.3508061,
+          0.35214793, 0.3508061, 0.36322694, 0.39965815, 0.5797223,
+          0.62928599, 1.0]
+     w = [1.00000000e+12, 6.88875973e+02, 4.89314737e+02, 4.26864807e+02,
+          6.07746770e+02, 4.51341444e+02, 3.17480210e+02, 4.51341444e+02,
+          6.07746770e+02, 4.26864807e+02, 4.89314737e+02, 6.88875973e+02,
+          1.00000000e+12]
+     spl = Spline1D(x, y; w = w, s = Float64(length(x)))
+     desired = [0.35100374, 0.51715855, 0.87789547, 0.98719344]
+     actual = evaluate(spl, [0.1, 0.5, 0.9, 0.99])
+     @test isapprox(actual, desired, atol = 5e-4)
 
-# test ported from scipy.interpolate testing this bug:
-# http://mail.scipy.org/pipermail/scipy-dev/2008-March/008507.html
-x = [-1.0, -0.65016502, -0.58856235, -0.26903553, -0.17370892,
-     -0.10011001, 0.0, 0.10011001, 0.17370892, 0.26903553, 0.58856235,
-     0.65016502, 1.0]
-y = [1.0, 0.62928599, 0.5797223, 0.39965815, 0.36322694, 0.3508061,
-     0.35214793, 0.3508061, 0.36322694, 0.39965815, 0.5797223,
-     0.62928599, 1.0]
-w = [1.00000000e+12, 6.88875973e+02, 4.89314737e+02, 4.26864807e+02,
-     6.07746770e+02, 4.51341444e+02, 3.17480210e+02, 4.51341444e+02,
-     6.07746770e+02, 4.26864807e+02, 4.89314737e+02, 6.88875973e+02,
-     1.00000000e+12]
-spl = Spline1D(x, y; w = w, s = Float64(length(x)))
-desired = [0.35100374, 0.51715855, 0.87789547, 0.98719344]
-actual = evaluate(spl, [0.1, 0.5, 0.9, 0.99])
-@test isapprox(actual, desired, atol = 5e-4)
+     @testset "periodic" begin
+          x = [1.0, 2.0, 3.0, 4.0, 5.0]
+          y = [4.0, 1.0, 4.0, 1.0, 4.0]
+          spl = Spline1D(x, y, periodic = true)
 
-# test periodic
-x = [1.0, 2.0, 3.0, 4.0, 5.0]
-y = [4.0, 1.0, 4.0, 1.0, 4.0]
-spl = Spline1D(x, y, periodic = true)
+          @test derivative(spl, 1) ≈ derivative(spl, 5)
+          @test derivative(spl, 1, nu = 2) ≈ derivative(spl, 5, nu = 2)
+     end
 
-@test derivative(spl, 1) ≈ derivative(spl, 5)
-@test derivative(spl, 1, nu = 2) ≈ derivative(spl, 5, nu = 2)
+     @testset "out-of-range" begin
+          x = [0.0:4.0;]
+          y = x .^ 3
 
-# tests for out-of-range
-x = [0.0:4.0;]
-y = x .^ 3
+          xp = range(-8.0, stop = 13.0, length = 100)
+          xp_zeros = Float64[(0.0 <= xi <= 4.0) ? xi : 0.0 for xi in xp]
+          xp_clip = Float64[(0.0 <= xi <= 4.0) ? xi : (xi < 0.0) ? 0.0 : 4.0 for xi in xp]
 
-xp = range(-8.0, stop = 13.0, length = 100)
-xp_zeros = Float64[(0.0 <= xi <= 4.0) ? xi : 0.0 for xi in xp]
-xp_clip = Float64[(0.0 <= xi <= 4.0) ? xi : (xi < 0.0) ? 0.0 : 4.0 for xi in xp]
+          spl = Spline1D(x, y)
+          t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
+          spl2 = Spline1D(x, y, t)
 
-spl = Spline1D(x, y)
-t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
-spl2 = Spline1D(x, y, t)
+          @test evaluate(spl, xp) ≈ xp_clip .^ 3
+          @test evaluate(spl2, xp) ≈ xp_clip .^ 3
 
-@test evaluate(spl, xp) ≈ xp_clip .^ 3
-@test evaluate(spl2, xp) ≈ xp_clip .^ 3
+          @testset "other bc's" begin
+               spl = Spline1D(x, y; bc = "extrapolate")
+               @test evaluate(spl, xp) ≈ xp .^ 3
+               spl = Spline1D(x, y; bc = "zero")
+               @test evaluate(spl, xp) ≈ xp_zeros .^ 3
+               spl = Spline1D(x, y; bc = "error")
+               @test_throws ErrorException evaluate(spl, xp)
 
-# test other bc's
-spl = Spline1D(x, y; bc = "extrapolate")
-@test evaluate(spl, xp) ≈ xp .^ 3
-spl = Spline1D(x, y; bc = "zero")
-@test evaluate(spl, xp) ≈ xp_zeros .^ 3
-spl = Spline1D(x, y; bc = "error")
-@test_throws ErrorException evaluate(spl, xp)
+          end
 
-# test unknown bc
-@test_throws ErrorException Spline1D(x, y; bc = "unknown")
-
-# test derivative
-x = range(0, stop = 1, length = 70)
-y = x .^ 3
-spl = Spline1D(x, y)
-xt = [0.3, 0.4, 0.5]
-@test derivative(spl, xt) ≈ 3xt .^ 2
-
-# test integral
-x = range(0, stop = 10, length = 70)
-y = x .^ 2
-spl = Spline1D(x, y)
-@test integrate(spl, 1.0, 5.0) ≈ 5.0^3 / 3 - 1 / 3
-
-# test roots
-x = range(0, stop = 10, length = 70)
-y = (x .- 4) .^ 2 .- 1
-spl = Spline1D(x, y)
-@test roots(spl) ≈ [3, 5]
-
-# test that show works.
-io = IOBuffer()
-show(io, spl)
-seek(io, 0)
-s = read(io, String)
-@test s[1:9] == "Spline1D("
-
-# test equality
-seed!(0)
-x = sort(rand(10))
-y = rand(10)
-sp1 = Spline1D(x, y)
-sp2 = Spline1D(x, y)
-sp3 = Spline1D(x .+ 1, y)
-sp4 = Spline1D(x, y .+ 1)
-@test sp1 == sp2
-@test allunique([sp1, sp3, sp4])
-
-
-# -----------------------------------------------------------------------------
-# ParametricSpline
-
-u = [1.0, 2.0, 3.0]
-x = [1.0 2.0 3.0; 0.0 2.0 4.0]
-spl = ParametricSpline(u, x, k = 1, s = size(x, 2))
-
-xi = evaluate(spl, [1.0, 1.5, 2.0])
-@test xi ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
-@test evaluate(spl, 1.5) ≈ [1.5, 1.0]
-@test get_knots(spl) ≈ [1.0, 3.0]
-@test get_coeffs(spl) ≈ [1.0 3.0; 0.0 4.0]
-@test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
-
-@test spl([1.0, 1.5, 2.0]) ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
-@test spl(1.5) ≈ [1.5, 1.0]
-
-# test that a copy is returned by get_knots()
-knots = get_knots(spl)
-knots[1] = 1000.0
-@test get_knots(spl) ≈ [1.0, 3.0]
-
-# test periodic
-x = [23.0 24.0 25.0 25.0 24.0 23.0
-     13.0 12.0 12.0 13.0 13.0 13.0]
-spl = ParametricSpline(x, periodic = true)
-@test evaluate(spl, 0) ≈ evaluate(spl, 1)
-@test derivative(spl, 0) ≈ derivative(spl, 1)
-@test derivative(spl, 0, nu = 2) ≈ derivative(spl, 1, nu = 2)
-
-# tests for out-of-range
-u = 0.0:4.0
-x = [u' .^ 2; u' .^ 3]
-
-up = range(-8.0, stop = 13.0, length = 100)
-up_zeros = Float64[(0.0 <= ui <= 4.0) ? ui : 0.0 for ui in up]
-up_clip = Float64[(0.0 <= ui <= 4.0) ? ui : (ui < 0.0) ? 0.0 : 4.0 for ui in up]
-
-spl = ParametricSpline(u, x)
-t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
-spl2 = ParametricSpline(u, x, t)
-
-@test evaluate(spl, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
-@test evaluate(spl2, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
-
-# test other bc's
-spl = ParametricSpline(u, x; bc = "extrapolate")
-@test evaluate(spl, up) ≈ [up' .^ 2; up' .^ 3]
-spl = ParametricSpline(u, x; bc = "zero")
-@test evaluate(spl, up) ≈ [up_zeros' .^ 2; up_zeros' .^ 3]
-spl = ParametricSpline(u, x; bc = "error")
-@test_throws ErrorException evaluate(spl, up)
-
-# test unknown bc
-@test_throws ErrorException ParametricSpline(u, x; bc = "unknown")
-
-# test derivative
-u = range(0, stop = 1, length = 70)
-x = [u' .^ 2; u' .^ 3]
-spl = ParametricSpline(u, x)
-ut = [0.3, 0.4, 0.5]
-@test derivative(spl, 0.3) ≈ [2 * 0.3, 3 * 0.3^2]
-@test derivative(spl, ut) ≈ [2 * ut'; 3 * ut' .^ 2]
-@test derivative(spl, 0.3, nu = 2) ≈ [2.0, 6 * 0.3]
-@test derivative(spl, ut, nu = 2) ≈ [2 * ones(3)'; 6 * ut']
-
-# test integral
-u = range(0, stop = 10, length = 70)
-x = [u' .^ 2; u' .^ 3]
-spl = ParametricSpline(u, x)
-@test integrate(spl, 1.0, 5.0) ≈ [5.0^3 / 3 - 1 / 3, 5.0^4 / 4 - 1 / 4]
-
-# test that show works.
-io = IOBuffer()
-show(io, spl)
-seek(io, 0)
-s = read(io, String)
-@test s[1:17] == "ParametricSpline("
-
-
-# test equality
-seed!(0)
-x = sort(rand(10))
-y = rand(3, 10)
-sp1 = ParametricSpline(x, y)
-sp2 = ParametricSpline(x, y)
-sp3 = ParametricSpline(x .+ 1, y)
-sp4 = ParametricSpline(x, y .+ 1)
-@test sp1 == sp2
-@test allunique([sp1, sp3, sp4])
-
-# test too many roots warning
-x = (0:100)
-y = (-1) .^ (0:100)
-sp = Spline1D(x, y)
-@test_logs (:warn, Regex("number of zeros exceeded")) roots(sp)
-
-
-# -----------------------------------------------------------------------------
-# Spline2D
-
-# test linear
-x = [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0]
-y = [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
-z = [0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0]
-spl = Spline2D(x, y, z; kx = 1, ky = 1, s = length(x))
-tx, ty = get_knots(spl)
-@test tx ≈ [1.0, 3.0]
-@test ty ≈ [1.0, 3.0]
-@test isapprox(get_residual(spl), 0.0, atol = 1e-16)
-@test evaluate(spl, 2.0, 1.5) ≈ 2.0
-@test evalgrid(spl, [1.0, 1.5, 2.0], [1.0, 1.5]) ≈ [0.0 0.0; 1.0 1.0; 2.0 2.0]
-
-# test 1-d grid arrays
-@test evalgrid(spl, [2.0], [1.5])[1, 1] ≈ 2.0
-
-# In this setting, lwrk2 is too small in the default run.
-x = range(-2, stop = 2, length = 80)
-y = range(-2, stop = 2, length = 80)
-z = x .+ y
-spl = Spline2D(x, y, z; s = length(x))
-@test evaluate(spl, 1.0, 1.0) ≈ 2.0
-
-# In this setting lwrk2 is too small multiple times!
-# Eventually an error about s being too small is thrown.
-seed!(0)
-x = rand(100)
-y = rand(100)
-z = sin.(x) .* sin.(y)
-@test_throws ErrorException Spline2D(x, y, z; kx = 1, ky = 1, s = 0.0)
-
-# test grid input creation
-x = [0.5, 2.0, 3.0, 4.0, 5.5, 8.0]
-y = [0.5, 2.0, 3.0, 4.0]
-z = [1.0 2.0 1.0 2.0  # shape is (nx, ny)
-     1.0 2.0 1.0 2.0
-     1.0 2.0 3.0 2.0
-     1.0 2.0 2.0 2.0
-     1.0 2.0 1.0 2.0
-     1.0 2.0 3.0 1.0]
-spl = Spline2D(x, y, z)
-
-# element-wise output
-xi = [1.0, 1.5, 2.3, 4.5, 3.3, 3.2, 3.0]
-yi = [1.0, 2.3, 5.3, 0.5, 3.3, 1.2, 3.0]
-ans = [2.94429906542,
-     1.25537598131,
-     2.00063588785,
-     1.0,
-     2.93952664,
-     1.06482509358,
-     3.0]
-zi = evaluate(spl, xi, yi)
-@test zi ≈ ans
-
-zi = spl(xi, yi)
-@test zi ≈ ans
-
-# grid output
-xi = [1.0, 1.5, 2.3, 4.5]
-yi = [1.0, 2.3, 5.3]
-ans = [2.94429906542 1.16946130841 1.99831775701
-     2.80393858478 1.25537598131 1.99873831776
-     1.67143209613 1.94853338542 2.00063588785
-     1.89392523364 1.8126946729 2.01042056075]
-zi = evalgrid(spl, xi, yi)
-@test zi ≈ ans
-
-
-# Test 2-d integration
-test2d_1(x, y) = 1 - x^2 - y^2
-test2d_2(x, y) = cos(x) + sin(y)
-test2d_3(x, y) = x * exp(x - y)
-for (f, domain, exact) in [(test2d_1, (0.0, 1.0, 0.0, 1.0), 1.0 / 3.0),
-     (test2d_2, (0.0, pi, 0.0, pi), 2.0 * pi),
-     (test2d_3, (0.0, 1.0, 0.0, 1.0), (ℯ - 1.0) / ℯ)]
-     (x0, x1, y0, y1) = domain
-
-     # define grids for x and y dimensions:
-     npoints = 50
-     xgrid = range(x0, stop = x1, length = npoints)
-     ygrid = range(y0, stop = y1, length = npoints)
-
-     fxygrid = zeros(npoints, npoints)
-     for (j, y) in enumerate(ygrid)
-          local j, y
-          for (i, x) in enumerate(xgrid)
-               local i, x
-               fxygrid[i, j] = f(x, y)
+          @testset "unknown bc" begin
+               @test_throws ErrorException Spline1D(x, y; bc = "unknown")
           end
      end
 
-     spl1 = Spline2D(xgrid, ygrid, fxygrid)
-     @test isapprox(integrate(spl1, x0, x1, y0, y1), exact, atol = 1e-6)
-end
+     @testset "derivative" begin
+          x = range(0, stop = 1, length = 70)
+          y = x .^ 3
+          spl = Spline1D(x, y)
+          xt = [0.3, 0.4, 0.5]
+          @test derivative(spl, xt) ≈ 3xt .^ 2
+     end
 
-# test derivative
-@testset "2D spline derivative" begin
-     x = Vector{Float64}(1:4)
-     y = Vector{Float64}(1:5)
-     z = (x .^ 2) * (y .^ 3)'
-     s = Spline2D(x, y, z)
-     @testset "ddx" begin
-          for xi in x, yi in y
-               @test derivative(s, xi, yi, nux = 1, nuy = 0) ≈ 2xi * yi^3
-          end
+     @testset "integral" begin
+          x = range(0, stop = 10, length = 70)
+          y = x .^ 2
+          spl = Spline1D(x, y)
+          @test integrate(spl, 1.0, 5.0) ≈ 5.0^3 / 3 - 1 / 3
      end
-     @testset "d2dx2" begin
-          for xi in x, yi in y
-               @test derivative(s, xi, yi, nux = 2, nuy = 0) ≈ 2yi^3
-          end
+
+     @testset "roots" begin
+          x = range(0, stop = 10, length = 70)
+          y = (x .- 4) .^ 2 .- 1
+          spl = Spline1D(x, y)
+          @test roots(spl) ≈ [3, 5]
      end
-     @testset "ddy" begin
-          for xi in x, yi in y
-               @test derivative(s, xi, yi, nux = 0, nuy = 1) ≈ 3xi^2 * yi^2
-          end
+
+     @testset "show" begin
+          io = IOBuffer()
+          show(io, spl)
+          seek(io, 0)
+          s = read(io, String)
+          @test s[1:9] == "Spline1D("
      end
-     @testset "d2dy2" begin
-          for xi in x, yi in y
-               @test derivative(s, xi, yi, nux = 0, nuy = 2) ≈ 6xi^2 * yi
-          end
-     end
-     @testset "ddx_ddy" begin
-          for xi in x, yi in y
-               @test derivative(s, xi, yi, nux = 1, nuy = 1) ≈ 6xi * yi^2
-          end
+
+     @testset "equality" begin
+          seed!(0)
+          x = sort(rand(10))
+          y = rand(10)
+          sp1 = Spline1D(x, y)
+          sp2 = Spline1D(x, y)
+          sp3 = Spline1D(x .+ 1, y)
+          sp4 = Spline1D(x, y .+ 1)
+          @test sp1 == sp2
+          @test allunique([sp1, sp3, sp4])
      end
 end
 
-# test equality
-seed!(0)
-x = sort(rand(10))
-y = sort(rand(10))
-z = rand(10, 10)
-sp1 = Spline2D(x, y, z)
-sp2 = Spline2D(x, y, z)
-sp3 = Spline2D(x .+ 1, y, z)
-sp4 = Spline2D(x, y .+ 1, z)
-sp5 = Spline2D(x, y, z .+ 1)
-@test sp1 == sp2
-@test allunique([sp1, sp3, sp4, sp5])
+# -----------------------------------------------------------------------------
+@testset "ParametricSpline" begin
+     u = [1.0, 2.0, 3.0]
+     x = [1.0 2.0 3.0; 0.0 2.0 4.0]
+     spl = ParametricSpline(u, x, k = 1, s = size(x, 2))
 
-println("All tests passed.")
+     xi = evaluate(spl, [1.0, 1.5, 2.0])
+     @test xi ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
+     @test evaluate(spl, 1.5) ≈ [1.5, 1.0]
+     @test get_knots(spl) ≈ [1.0, 3.0]
+     @test get_coeffs(spl) ≈ [1.0 3.0; 0.0 4.0]
+     @test isapprox(get_residual(spl), 0.0, atol = 1.e-30)
+
+     @test spl([1.0, 1.5, 2.0]) ≈ [1.0 1.5 2.0; 0.0 1.0 2.0]
+     @test spl(1.5) ≈ [1.5, 1.0]
+
+     @testset "a copy is returned by get_knots()" begin
+          knots = get_knots(spl)
+          knots[1] = 1000.0
+          @test get_knots(spl) ≈ [1.0, 3.0]
+     end
+
+     @testset "periodic" begin
+          x = [23.0 24.0 25.0 25.0 24.0 23.0
+               13.0 12.0 12.0 13.0 13.0 13.0]
+          spl = ParametricSpline(x, periodic = true)
+          @test evaluate(spl, 0) ≈ evaluate(spl, 1)
+          @test derivative(spl, 0) ≈ derivative(spl, 1)
+          @test derivative(spl, 0, nu = 2) ≈ derivative(spl, 1, nu = 2)
+     end
+
+     @testset "out-of-range" begin
+          u = 0.0:4.0
+          x = [u' .^ 2; u' .^ 3]
+
+          up = range(-8.0, stop = 13.0, length = 100)
+          up_zeros = Float64[(0.0 <= ui <= 4.0) ? ui : 0.0 for ui in up]
+          up_clip = Float64[(0.0 <= ui <= 4.0) ? ui : (ui < 0.0) ? 0.0 : 4.0 for ui in up]
+
+          spl = ParametricSpline(u, x)
+          t = get_knots(spl)[2:end-1]  # knots, excluding those at endpoints
+          spl2 = ParametricSpline(u, x, t)
+
+          @test evaluate(spl, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
+          @test evaluate(spl2, up) ≈ [up_clip' .^ 2; up_clip' .^ 3]
+
+          @testset "other bc's" begin
+               spl = ParametricSpline(u, x; bc = "extrapolate")
+               @test evaluate(spl, up) ≈ [up' .^ 2; up' .^ 3]
+               spl = ParametricSpline(u, x; bc = "zero")
+               @test evaluate(spl, up) ≈ [up_zeros' .^ 2; up_zeros' .^ 3]
+               spl = ParametricSpline(u, x; bc = "error")
+               @test_throws ErrorException evaluate(spl, up)
+
+          end
+
+          @testset "unknown bc" begin
+               @test_throws ErrorException ParametricSpline(u, x; bc = "unknown")
+          end
+     end
+
+     @testset "derivative" begin
+          u = range(0, stop = 1, length = 70)
+          x = [u' .^ 2; u' .^ 3]
+          spl = ParametricSpline(u, x)
+          ut = [0.3, 0.4, 0.5]
+          @test derivative(spl, 0.3) ≈ [2 * 0.3, 3 * 0.3^2]
+          @test derivative(spl, ut) ≈ [2 * ut'; 3 * ut' .^ 2]
+          @test derivative(spl, 0.3, nu = 2) ≈ [2.0, 6 * 0.3]
+          @test derivative(spl, ut, nu = 2) ≈ [2 * ones(3)'; 6 * ut']
+     end
+
+     @testset "integral" begin
+          u = range(0, stop = 10, length = 70)
+          x = [u' .^ 2; u' .^ 3]
+          spl = ParametricSpline(u, x)
+          @test integrate(spl, 1.0, 5.0) ≈ [5.0^3 / 3 - 1 / 3, 5.0^4 / 4 - 1 / 4]
+     end
+
+     @testset "show" begin
+          io = IOBuffer()
+          show(io, spl)
+          seek(io, 0)
+          s = read(io, String)
+          @test s[1:17] == "ParametricSpline("
+     end
+
+     @testset "equality" begin
+          seed!(0)
+          x = sort(rand(10))
+          y = rand(3, 10)
+          sp1 = ParametricSpline(x, y)
+          sp2 = ParametricSpline(x, y)
+          sp3 = ParametricSpline(x .+ 1, y)
+          sp4 = ParametricSpline(x, y .+ 1)
+          @test sp1 == sp2
+          @test allunique([sp1, sp3, sp4])
+     end
+
+     @testset "too many roots warning" begin
+          x = (0:100)
+          y = (-1) .^ (0:100)
+          sp = Spline1D(x, y)
+          @test_logs (:warn, Regex("number of zeros exceeded")) roots(sp)
+     end
+end
+
+# -----------------------------------------------------------------------------
+@testset "Spline2D" begin
+     @testset "linear" begin
+          x = [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0]
+          y = [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
+          z = [0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0]
+          spl = Spline2D(x, y, z; kx = 1, ky = 1, s = length(x))
+          tx, ty = get_knots(spl)
+          @test tx ≈ [1.0, 3.0]
+          @test ty ≈ [1.0, 3.0]
+          @test isapprox(get_residual(spl), 0.0, atol = 1e-16)
+          @test evaluate(spl, 2.0, 1.5) ≈ 2.0
+          @test evalgrid(spl, [1.0, 1.5, 2.0], [1.0, 1.5]) ≈ [0.0 0.0; 1.0 1.0; 2.0 2.0]
+
+          @testset "1-d grid arrays" begin
+               @test evalgrid(spl, [2.0], [1.5])[1, 1] ≈ 2.0
+          end
+     end
+
+     @testset "too small lwrk2" begin
+          # In this setting, lwrk2 is too small in the default run.
+          x = range(-2, stop = 2, length = 80)
+          y = range(-2, stop = 2, length = 80)
+          z = x .+ y
+          spl = Spline2D(x, y, z; s = length(x))
+          @test evaluate(spl, 1.0, 1.0) ≈ 2.0
+
+          # In this setting lwrk2 is too small multiple times!
+          # Eventually an error about s being too small is thrown.
+          seed!(0)
+          x = rand(100)
+          y = rand(100)
+          z = sin.(x) .* sin.(y)
+          @test_throws ErrorException Spline2D(x, y, z; kx = 1, ky = 1, s = 0.0)
+     end
+
+     @testset "grid input creation" begin
+          x = [0.5, 2.0, 3.0, 4.0, 5.5, 8.0]
+          y = [0.5, 2.0, 3.0, 4.0]
+          z = [1.0 2.0 1.0 2.0  # shape is (nx, ny)
+               1.0 2.0 1.0 2.0
+               1.0 2.0 3.0 2.0
+               1.0 2.0 2.0 2.0
+               1.0 2.0 1.0 2.0
+               1.0 2.0 3.0 1.0]
+          spl = Spline2D(x, y, z)
+          # element-wise output
+          @testset "element wise output" begin
+               xi = [1.0, 1.5, 2.3, 4.5, 3.3, 3.2, 3.0]
+               yi = [1.0, 2.3, 5.3, 0.5, 3.3, 1.2, 3.0]
+               ans = [2.94429906542,
+                    1.25537598131,
+                    2.00063588785,
+                    1.0,
+                    2.93952664,
+                    1.06482509358,
+                    3.0]
+               zi = evaluate(spl, xi, yi)
+               @test zi ≈ ans
+
+               zi = spl(xi, yi)
+               @test zi ≈ ans
+          end
+          @testset "grid output" begin
+               xi = [1.0, 1.5, 2.3, 4.5]
+               yi = [1.0, 2.3, 5.3]
+               ans = [2.94429906542 1.16946130841 1.99831775701
+                    2.80393858478 1.25537598131 1.99873831776
+                    1.67143209613 1.94853338542 2.00063588785
+                    1.89392523364 1.8126946729 2.01042056075]
+               zi = evalgrid(spl, xi, yi)
+               @test zi ≈ ans
+          end
+     end
+
+     # Test 2-d integration
+     @testset "integration" begin
+          test2d_1(x, y) = 1 - x^2 - y^2
+          test2d_2(x, y) = cos(x) + sin(y)
+          test2d_3(x, y) = x * exp(x - y)
+          for (f, domain, exact) in [(test2d_1, (0.0, 1.0, 0.0, 1.0), 1.0 / 3.0),
+               (test2d_2, (0.0, pi, 0.0, pi), 2.0 * pi),
+               (test2d_3, (0.0, 1.0, 0.0, 1.0), (ℯ - 1.0) / ℯ)]
+               (x0, x1, y0, y1) = domain
+
+               # define grids for x and y dimensions:
+               npoints = 50
+               xgrid = range(x0, stop = x1, length = npoints)
+               ygrid = range(y0, stop = y1, length = npoints)
+
+               fxygrid = zeros(npoints, npoints)
+               for (j, y) in enumerate(ygrid)
+                    local j, y
+                    for (i, x) in enumerate(xgrid)
+                         local i, x
+                         fxygrid[i, j] = f(x, y)
+                    end
+               end
+
+               spl1 = Spline2D(xgrid, ygrid, fxygrid)
+               @test isapprox(integrate(spl1, x0, x1, y0, y1), exact, atol = 1e-6)
+          end
+     end
+
+     # test derivative
+     @testset "derivative" begin
+          x = Vector{Float64}(1:4)
+          y = Vector{Float64}(1:5)
+          z = (x .^ 2) * (y .^ 3)'
+          s = Spline2D(x, y, z)
+          @testset "ddx" begin
+               for xi in x, yi in y
+                    @test derivative(s, xi, yi, nux = 1, nuy = 0) ≈ 2xi * yi^3
+               end
+          end
+          @testset "d2dx2" begin
+               for xi in x, yi in y
+                    @test derivative(s, xi, yi, nux = 2, nuy = 0) ≈ 2yi^3
+               end
+          end
+          @testset "ddy" begin
+               for xi in x, yi in y
+                    @test derivative(s, xi, yi, nux = 0, nuy = 1) ≈ 3xi^2 * yi^2
+               end
+          end
+          @testset "d2dy2" begin
+               for xi in x, yi in y
+                    @test derivative(s, xi, yi, nux = 0, nuy = 2) ≈ 6xi^2 * yi
+               end
+          end
+          @testset "ddx_ddy" begin
+               for xi in x, yi in y
+                    @test derivative(s, xi, yi, nux = 1, nuy = 1) ≈ 6xi * yi^2
+               end
+          end
+     end
+
+     # test equality
+     @testset "equality" begin
+          seed!(0)
+          x = sort(rand(10))
+          y = sort(rand(10))
+          z = rand(10, 10)
+          sp1 = Spline2D(x, y, z)
+          sp2 = Spline2D(x, y, z)
+          sp3 = Spline2D(x .+ 1, y, z)
+          sp4 = Spline2D(x, y .+ 1, z)
+          sp5 = Spline2D(x, y, z .+ 1)
+          @test sp1 == sp2
+          @test allunique([sp1, sp3, sp4, sp5])
+     end
+end


### PR DESCRIPTION
~A bunch of whitespace changes are introduced by the VScode plugin, sorry about these, but hopefully these will improve readability.~

The main change introduced here is the ability to compute partial derivatives of 2D splines.

```julia
julia> x = Vector{Float64}(1:4); y = Vector{Float64}(1:5); z = (x.^2) * (y.^3)'
4×5 Matrix{Float64}:
  1.0    8.0   27.0    64.0   125.0
  4.0   32.0  108.0   256.0   500.0
  9.0   72.0  243.0   576.0  1125.0
 16.0  128.0  432.0  1024.0  2000.0

julia> s = Spline2D(x, y, z);

julia> derivative(s, 1, 1, nuy=1, nux=0) # 3x^2y^2
3.000000000000028

julia> derivative(s, 1, 1, nuy=0, nux=1) # 2xy^3
1.9999999999999887

julia> derivative(s, 1, 1, nuy=1, nux=1) # 6xy^2
6.000000000000547
```

~I've also taken the liberty to refactor the tests by introducing `testsets`.~